### PR TITLE
Fixed the problem when a user/space is created with the same identifier of another

### DIFF
--- a/app/assets/javascripts/app/spaces/new.js.coffee
+++ b/app/assets/javascripts/app/spaces/new.js.coffee
@@ -1,0 +1,26 @@
+# http://dense13.com/blog/2009/05/03/converting-string-to-slug-javascript/
+stringToSlug = (str) ->
+  str = str.replace(/^\s+|\s+$/g, '')
+  str = str.toLowerCase()
+
+  # remove accents, swap ñ for n, etc
+  from = "ãàáäâẽèéëêĩìíïîõòóöôũùúüûñçć·/_,:;!"
+  to   = "aaaaaeeeeeiiiiiooooouuuuuncc-------"
+  for i in [0..from.length]
+    str = str.replace(new RegExp(from.charAt(i), 'g'), to.charAt(i))
+
+  str.replace(/[^a-z0-9 -]/g, '') # remove invalid chars
+     .replace(/\s+/g, '-') # collapse whitespace and replace by -
+     .replace(/-+/g, '-') # collapse dashes
+
+class mconf.NewSpaceForm
+  @setup: ->
+    $name = $("#space_name")
+    $permalink = $("#space_permalink")
+    $permalink.attr "value", stringToSlug($name.val())
+    $name.on "input keyup", () ->
+      $permalink.attr "value", stringToSlug($name.val())
+
+$ ->
+  if isOnPage 'spaces', 'new'
+    mconf.NewSpaceForm.setup()

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,14 @@ class User < ActiveRecord::Base
                        :presence => true,
                        :format => /^[A-Za-z0-9\-_]*$/,
                        :length => { :minimum => 1 }
+
+  validate :username_uniqueness, :on => :create
+
+  # Validates the username against params of bigbluebutton rooms
+  def username_uniqueness
+    errors.add(:username, "has already been taken") unless Space.find_by_permalink(self.username).blank?
+  end
+
   extend FriendlyId
   friendly_id :username
 

--- a/app/views/spaces/new.html.haml
+++ b/app/views/spaces/new.html.haml
@@ -25,6 +25,7 @@
   = simple_form_for @space, :html => { :method => :post }, :url => spaces_path do |f|
     #new-space-basic-info
       = f.input :name, :autofocus => true
+      = f.input :permalink, :label => t(".permalink")
       = f.input :description, :as => :text
       = f.input :public
     = f.button :wrapped, :value => t("_other.create")

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -1441,6 +1441,7 @@ en:
           no_matches: "No spaces found for \"%{term}\""
           placeholder: "Search spaces..."
     new:
+      permalink: "Space ID"
       private: "Private"
       public: "Public"
       spaces_examples:

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -1419,6 +1419,7 @@ pt-br:
           no_matches: "Nenhuma comunidae encontrada com \"%{term}\""
           placeholder: "Procurar comunidaes..."
     new:
+      permalink: "Space ID"
       private: "Privada"
       public: "Pública"
       spaces_examples:

--- a/lib/forgery/forgeries/internet.rb
+++ b/lib/forgery/forgeries/internet.rb
@@ -8,4 +8,8 @@ class Forgery::Internet < Forgery
     "#{self.user_name}-#{n}"
   end
 
+  def self.unique_permalink(p)
+    "#{self.user_name}-#{p}"
+  end
+
 end

--- a/spec/factories/definitions.rb
+++ b/spec/factories/definitions.rb
@@ -7,5 +7,6 @@
 FactoryGirl.define do
   sequence(:email) { |n| Forgery::Internet.unique_email_address(n) }
   sequence(:username) { |n| Forgery::Internet.unique_user_name(n) }
+  sequence(:permalink) { |n| Forgery::Internet.unique_permalink(n) }
   sequence(:timezone) { |n| Forgery::Time.zone }
 end

--- a/spec/factories/space.rb
+++ b/spec/factories/space.rb
@@ -6,6 +6,7 @@
 
 FactoryGirl.define do
   factory :space do |s|
+    s.permalink
     s.sequence(:name) { |n| Forgery::Name.unique_space_name(n) }
     s.description { Forgery::Basic.text }
     s.public false

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -80,6 +80,14 @@ describe Space do
 
   it "default_scope :conditions"
 
+  describe "on create" do
+    describe "verify if doesn't exist a user with the same username of the space permalink" do
+      before(:each) { FactoryGirl.create(:user, :username => "test") }
+      before(:each) { FactoryGirl.build(:space, :permalink => "test") }
+      it { should_not be_valid }
+    end
+  end
+
   describe ".public" do
     context "returns the admins of the space" do
       before {

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -82,6 +82,12 @@ describe User do
   end
 
   describe "on create" do
+    describe "verify if doesn't exist a space with the same permalink of the username" do
+      before(:each) { FactoryGirl.create(:space, :permalink => "test") }
+      before(:each) { FactoryGirl.build(:user, :username => "test") }
+      it { should_not be_valid }
+    end
+
     describe "#automatically_approve_if_needed" do
       context "if #require_registration_approval is not set in the current site" do
         before { Site.current.update_attributes(:require_registration_approval => false) }


### PR DESCRIPTION
When a user or a space are created the system try to create his room using the username/permalink like param. This can result in a error, because the room can't be created with a param equal to another. To resolve this issue a validate function was created in user/space model to verify if doesn't exist another model with the same identifier. If another identifier is found the model aren't created.

Fixed #1071
