### PR TITLE
Bug 1312 Local account is disabled user can't log in via federation

### DIFF
--- a/app/controllers/shibboleth_controller.rb
+++ b/app/controllers/shibboleth_controller.rb
@@ -44,7 +44,14 @@ class ShibbolethController < ApplicationController
 
       # no token means the user has no association yet, render a page to do it
       else
-        unless get_always_new_account
+        if !token.nil? && token.user.nil? 
+          user = User.with_disabled.where(id: token.user_id).first
+          if user.disabled
+            logger.info "Shibolleth: user local account is disabled, can't login"
+            flash[:error] = t('shibboleth.login.local_account_disabled')
+            redirect_to root_path
+          end
+        elsif !get_always_new_account
           logger.info "Shibboleth: first access for this user, rendering the association page"
           render :associate
         else

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -1320,6 +1320,8 @@ en:
       invalid_parameters: "Your request was invalid, please try again."
     info:
       title: "Your data from the federation"
+    login:
+      local_account_disabled: "Your account with Mconf is disabled, sorry but you can't log in. Please contact an adminstrator to solve the problem."
   show: Show
   show_advanced_editor: "Show advanced editor"
   show_list_version_arrows: "show list version >>"

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -1320,6 +1320,8 @@ pt-br:
       invalid_parameters: "Your request was invalid, please try again."
     info:
       title: "Seus dados obtidos pela federação"
+    login:
+      local_account_disabled: "Sua conta com o Mconf está desabilitada, você não pode se logar. Por favor, entre em contato com um administrador para resolver o probleme."
   show: Exibir
   show_advanced_editor: "Exibir editor avançado"
   show_list_version_arrows: "exibir versão em lista >>"

--- a/spec/controllers/shibboleth_controller_spec.rb
+++ b/spec/controllers/shibboleth_controller_spec.rb
@@ -140,6 +140,19 @@ describe ShibbolethController do
         }
       end
 
+      context "user has a token but his local account is disabled" do
+        before {
+          setup_shib(user.full_name, user.email)
+          ShibToken.create!(:identifier => user.email, :user => user)
+          user.update_attributes(:disabled => true)
+        }
+        before(:each) {
+          get :login
+        }
+        it { should set_the_flash.to(I18n.t('shibboleth.login.local_account_disabled'))}
+        it { should redirect_to(root_path) }
+      end
+
       context "renders the association page if the user doesn't have a token yet" do
         before(:each) { get :login }
         it { should render_template('associate') }


### PR DESCRIPTION
If the federation authentication is ok but the local account is disabled, the user is not allowed to login and it is redirected to root_path with an error message.
Note: requires ruby 2.2.0-dev (2.1.2 raises an error with hash serialization)

refs #1312
