### PR TITLE
Changed playback link on recordings.

### DIFF
--- a/app/views/shared/_recording_playback.html.haml
+++ b/app/views/shared/_recording_playback.html.haml
@@ -10,7 +10,7 @@
       - recording.playback_formats.ordered.each do |playback|
         - if playback.visible?
           %li
-            = link_to playback.name, playback.url, :class => 'playback-link open-new-window'
+            = link_to playback.name, play_bigbluebutton_recording_path(recording)
             - if show_duration
               %span.small-date= "(#{t('.duration')}: #{distance_of_time(playback.length_in_secs)})"
               - show_duration = false


### PR DESCRIPTION
Now uses the play route of the Bigbluebutton Recording controller, instead of using the link to the recording itself.

refs #1063
