### PR TITLE
Feature #1421 Subject on emails sent by devise are not like the others

### DIFF
--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -1,0 +1,20 @@
+class DeviseMailer < Devise::Mailer
+  helper :application
+  include Devise::Controllers::UrlHelpers
+  default template_path: 'devise/mailer'
+
+  def confirmation_instructions(record, token, opts={})
+    opts[:subject] = "[#{Site.current.name}] #{t('devise.mailer.confirmation_instructions.subject')}"
+    super
+  end
+
+  def reset_password_instructions(record, token, opts={})
+    opts[:subject] = "[#{Site.current.name}] #{t('devise.mailer.reset_password_instructions.subject')}"
+    super
+  end
+
+  def unlock_instructions(record, token, opts={})
+    opts[:subject] = "[#{Site.current.name}] #{t('devise.mailer.unlock_instructions.subject')}"
+    super
+  end
+end

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -2,6 +2,7 @@ class DeviseMailer < Devise::Mailer
   helper :application
   include Devise::Controllers::UrlHelpers
   default template_path: 'devise/mailer'
+  layout 'mailers'
 
   def confirmation_instructions(record, token, opts={})
     opts[:subject] = "[#{Site.current.name}] #{t('devise.mailer.confirmation_instructions.subject')}"

--- a/app/mailers/devise_mailer.rb
+++ b/app/mailers/devise_mailer.rb
@@ -13,9 +13,4 @@ class DeviseMailer < Devise::Mailer
     opts[:subject] = "[#{Site.current.name}] #{t('devise.mailer.reset_password_instructions.subject')}"
     super
   end
-
-  def unlock_instructions(record, token, opts={})
-    opts[:subject] = "[#{Site.current.name}] #{t('devise.mailer.unlock_instructions.subject')}"
-    super
-  end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -17,7 +17,7 @@ Devise.setup do |config|
   end
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = "Devise::Mailer"
+  config.mailer = "DeviseMailer"
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and
@@ -225,7 +225,7 @@ Devise.setup do |config|
   #
   config.warden do |manager|
     # manager.intercept_401 = false
-    manager.default_strategies(:scope => :user).unshift :ldap_authenticatable
+    manager.default_strategies(scope: :user).unshift :ldap_authenticatable
     # to add extra behavior to login redirection
     manager.failure_app = CustomFailedLoginRedirection
   end

--- a/spec/features/devise/confirmation_instructions_spec.rb
+++ b/spec/features/devise/confirmation_instructions_spec.rb
@@ -19,6 +19,7 @@ feature "Confirmation instructions" do
 
       # the email must have at least some text we expect and the confirmation link
       last_email.should_not be_nil
+      last_email.subject.should eql("[#{Site.current.name}] " + I18n.t('devise.mailer.confirmation_instructions.subject'))
       last_email.body.encoded.should match(/http.*users\/confirmation[^" ]*/)
       last_email.body.encoded.should match(t('devise.mailer.confirmation_instructions.confirmation_ok'))
       last_email.body.encoded.should match(t('devise.mailer.confirmation_instructions.welcome', email: user.email))
@@ -56,6 +57,7 @@ feature "Confirmation instructions" do
 
       # the email must have at least some text we expect and the confirmation link
       last_email.should_not be_nil
+      last_email.subject.should eql("[#{Site.current.name}] " + I18n.t('devise.mailer.confirmation_instructions.subject'))
       last_email.body.encoded.should match(/http.*users\/confirmation[^" ]*/)
       last_email.body.encoded.should match(t('devise.mailer.confirmation_instructions.confirmation_ok'))
       last_email.body.encoded.should match(t('devise.mailer.confirmation_instructions.welcome', email: user.email))

--- a/spec/features/devise/reset_password_instructions_spec.rb
+++ b/spec/features/devise/reset_password_instructions_spec.rb
@@ -10,7 +10,7 @@ feature "Reset password instructions" do
     }
     it("sets 'to'") { last_email.to.should eql([user.email]) }
     it("sets 'subject'") {
-      text = I18n.t('devise.mailer.reset_password_instructions.subject')
+      text = "[#{Site.current.name}] " + I18n.t('devise.mailer.reset_password_instructions.subject')
       last_email.subject.should eql(text)
     }
     it("sets 'from'") { last_email.from.should eql([Devise.mailer_sender]) }


### PR DESCRIPTION
The subject from devise emails was modified to match with the rest of the site emails.

refs #1421