### PR TITLE
Bug #1469 - Unnecessary emails when a user is registered by an admin and the flag "require admin approval" is set

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -193,11 +193,14 @@ class UsersController < ApplicationController
   end
 
   def create
+    params[:user][:notified] = true
     @user = User.new(user_params)
+    @user.skip_confirmation_notification!
 
     if @user.save
       @user.confirm!
       @user.approve!
+      @user.create_approval_notification(@user) if current_site.require_registration_approval?
       flash[:success] = t("users.create.success")
       respond_to do |format|
         format.html { redirect_to manage_users_path }
@@ -221,7 +224,7 @@ class UsersController < ApplicationController
   def allowed_params
     allowed = [ :password, :password_confirmation, :remember_me, :current_password,
       :login, :approved, :disabled, :timezone, :can_record, :receive_digest, :expanded_post ]
-    allowed += [:email, :username, :_full_name] if current_user.superuser? and (params[:action] == 'create')
+    allowed += [:email, :username, :_full_name, :notified] if current_user.superuser? and (params[:action] == 'create')
     allowed += [:superuser] if current_user.superuser? && current_user != @user
     allowed
   end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -16,4 +16,13 @@ class UserMailer < BaseMailer
     end
   end
 
+  def registration_by_admin_notification_email(user_id)
+    user = User.find(user_id)
+    I18n.with_locale(default_email_locale(user, nil)) do
+      @user_name = user.name
+      @subject = t("user_mailer.registration_by_admin_notification_email.subject")
+      create_email(user.email, Site.current.smtp_sender, @subject)
+    end
+  end
+
 end

--- a/app/mailers/views/user_mailer/registration_by_admin_notification_email.haml
+++ b/app/mailers/views/user_mailer/registration_by_admin_notification_email.haml
@@ -1,0 +1,8 @@
+#registration_by_admin_notification_email
+  .header
+    = @subject
+
+  %p= t('.message', name: @user_name, url: root_url(host: Site.current.domain), site: Site.current.name, feedback_url: new_feedback_url).html_safe
+
+  %p.link
+    = t('.click_here', url: my_home_url(host: Site.current.domain)).html_safe

--- a/app/mailers/views/user_mailer/registration_by_admin_notification_email.haml
+++ b/app/mailers/views/user_mailer/registration_by_admin_notification_email.haml
@@ -2,7 +2,7 @@
   .header
     = @subject
 
-  %p= t('.message', name: @user_name, url: root_url(host: Site.current.domain), site: Site.current.name, feedback_url: new_feedback_url).html_safe
+  %p= t('.message', name: @user_name, url: root_url(host: Site.current.domain), site: Site.current.name, feedback_url: new_feedback_url(host: Site.current.domain)).html_safe
 
   %p.link
     = t('.click_here', url: my_home_url(host: Site.current.domain)).html_safe

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -278,12 +278,18 @@ class User < ActiveRecord::Base
     Space.where(:id => ids)
   end
 
+  attr_accessor :notified
+
   after_create :new_activity_user_created
   def new_activity_user_created
-    create_activity 'created', owner: self, notified: !site_needs_approval?
+    if notified
+      create_activity 'created_by_admin', owner: self, notified: false
+    else
+      create_activity 'created', owner: self, notified: !site_needs_approval?
+    end
   end
 
   def new_activity_user_approved(approved_by)
-    create_activity 'approved', owner: approved_by
+    create_activity 'approved', owner: approved_by, notified: notified
   end
 end

--- a/app/workers/user_registered_by_admin_sender_worker.rb
+++ b/app/workers/user_registered_by_admin_sender_worker.rb
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# This file is part of Mconf-Web, a web application that provides access
+# to the Mconf webconferencing system. Copyright (C) 2010-2012 Mconf
+#
+# This file is licensed under the Affero General Public License version
+# 3 or later. See the LICENSE file.
+
+class UserRegisteredByAdminSenderWorker
+  @queue = :user_notifications
+
+  # Sends a notification to the user with id `user_id` that he was registered successfully.
+  def self.perform(activity_id)
+    activity = RecentActivity.find(activity_id)
+    user_id = activity.trackable_id
+
+    Resque.logger.info "Sending user registered email to #{user_id}"
+    UserMailer.registration_by_admin_notification_email(activity.trackable_id).deliver
+
+    activity.update_attribute(:notified, true)
+  end
+
+end

--- a/config/locales/en/_mailer.yml
+++ b/config/locales/en/_mailer.yml
@@ -19,6 +19,10 @@ en:
       message: "Hello %{name},<br/><br/>We're sending this email to inform you that your registration on <a href=\"%{url}\">%{site}</a> has completed successfully!"
       subject: "Your registration has been completed"
       confirmation_pending: "You have registered succesfully on <a href=\"%{url}\">%{site}</a> and your account was submitted to the approval of an administrator. You will be contacted when you account is approved."
+    registration_by_admin_notification_email:
+      click_here: "Click <a href=\"%{url}\">here</a> to go to your home page."
+      message: "Hello %{name}! We're sending this email to inform that you are successfully registered on <a href=\"%{url}\">%{site}</a>!<br><br>This account was registered by an administrator of the site, if you think this was a misunderstanding please contact us by <a href=\"%{feedback_url}\">clicking here</a>."
+      subject: "An account was created for you by an administrator"
   event_mailer:
     invitation_email:
       message:

--- a/config/locales/pt-br/_mailer.yml
+++ b/config/locales/pt-br/_mailer.yml
@@ -19,6 +19,10 @@ pt-br:
       message: "Olá %{name},<br/><br/>Estamos lhe mandando este email para informar que o seu registro em <a href=\"%{url}\">%{site}</a> foi concluído com sucesso!"
       subject: "Registro realizado com sucesso"
       confirmation_pending: "Seu cadastro foi efetivado com sucesso em <a href=\"%{url}\">%{site}</a> e submetido a aprovação do administrador responsável por validar o seu acesso. Assim que seu cadastro for aprovado você será comunicado."
+    registration_by_admin_notification_email:
+      click_here: "Clique <a href=\"%{url}\">aqui</a> para ir à sua página inicial."
+      message: "Olá %{name},<br/><br/>Estamos lhe mandando este email para informar que você foi registrado com sucesso em <a href=\"%{url}\">%{site}</a>!<br><br>Esta conta foi registrada por um administrador do site, se você acha que isso foi um mal entendido entre em contato conosco<a href=\"%{feedback_url}\">clicando aqui</a>."
+      subject: "Uma conta foi criada para você por um administrador."
   event_mailer:
     invitation_email:
       message:

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -819,7 +819,8 @@ describe UsersController do
         it { should redirect_to manage_users_path }
         it { User.last.confirmed?.should be true }
         it { User.last.approved?.should be true }
-        it('should not create an activity') { RecentActivity.where(key: 'user.approved').should be_empty }
+        it('should create an user created activity') { RecentActivity.where(key: 'user.created_by_admin').should_not be_empty }
+        it('should not create an user approved activity') { RecentActivity.where(key: 'user.approved').should be_empty }
       end
 
       describe "creates a new user with valid attributes and with the ability to record meetings" do
@@ -879,6 +880,8 @@ describe UsersController do
           it { User.last.confirmed?.should be true }
           it { User.last.approved?.should be true }
           it { User.last.can_record.should_not be true }
+          it('should create an user created activity') { RecentActivity.where(key: 'user.created_by_admin').should_not be_empty }
+          it('should create an user approved activity') { RecentActivity.where(key: 'user.approved').should_not be_empty }
         end
 
         describe "creates a new user with valid attributes and with the ability to record meetings" do

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -79,6 +79,74 @@ describe UserMailer do
     end
   end
 
+  describe '.registration_by_admin_notification_email' do
+    let(:user) { FactoryGirl.create(:user) }
+    let(:mail) { UserMailer.registration_by_admin_notification_email(user.id) }
+    let(:url) { my_home_url(host: Site.current.domain) }
+
+    context "in the standard case" do
+      it("sets 'to'") { mail.to.should eql([user.email]) }
+      it("sets 'subject'") {
+        text = I18n.t('user_mailer.registration_by_admin_notification_email.subject')
+        text = "[#{Site.current.name}] #{text}"
+        mail.subject.should eql(text)
+      }
+      it("sets 'from'") { mail.from.should eql([Site.current.smtp_sender]) }
+      it("sets 'headers'") { mail.headers.should eql({}) }
+      it("sets 'reply_to'") { mail.reply_to.should eql([Site.current.smtp_sender]) }
+
+      context "in body message" do
+        it("assigns @user_name") {
+          mail.body.encoded.should match(user.name)
+        }
+        it("sends a link to site root_path") {
+          mail.body.encoded.should match(root_url(host: Site.current.domain))
+        }
+        it("sends a link to site new_feedback_path") {
+          mail.body.should match(new_feedback_url(host: Site.current.domain))
+        }
+        it("sends a link to the users home_path") {
+          content = I18n.t('user_mailer.registration_by_admin_notification_email.click_here', url: url)
+          mail.body.encoded.should match(content)
+        }
+      end
+    end
+
+    context "uses the receiver's locale" do
+      before {
+        Site.current.update_attributes(:locale => "en")
+        user.update_attribute(:locale, "pt-br")
+      }
+      it {
+        content = I18n.t('user_mailer.registration_by_admin_notification_email.click_here', url: my_home_url(host: Site.current.domain), locale: "pt-br")
+        mail.body.encoded.should match(content)
+      }
+    end
+
+    context "uses the current site's locale if the receiver has no locale set" do
+      before {
+        Site.current.update_attributes(:locale => "pt-br")
+        user.update_attribute(:locale, nil)
+      }
+      it {
+        content = I18n.t('user_mailer.registration_by_admin_notification_email.click_here', url: my_home_url(host: Site.current.domain), locale: "pt-br")
+        mail.body.encoded.should match(content)
+      }
+    end
+
+    context "uses the default locale if the site has no locale set" do
+      before {
+        Site.current.update_attributes(:locale => nil)
+        I18n.default_locale = "pt-br"
+        user.update_attribute(:locale, nil)
+      }
+      it {
+        content = I18n.t('user_mailer.registration_by_admin_notification_email.click_here', url: my_home_url(host: Site.current.domain), locale: "pt-br")
+        mail.body.encoded.should match(content)
+      }
+    end
+  end
+
   context "calls the error handler on exceptions" do
     let(:exception) { Exception.new("test exception") }
     it {
@@ -86,6 +154,13 @@ describe UserMailer do
         BaseMailer.any_instance.stub(:render) { raise exception }
         Mconf::MailerErrorHandler.should_receive(:handle).with(UserMailer, nil, exception, "registration_notification_email", anything)
         UserMailer.registration_notification_email(1).deliver
+      end
+    }
+    it {
+      with_resque do
+        BaseMailer.any_instance.stub(:render) { raise exception }
+        Mconf::MailerErrorHandler.should_receive(:handle).with(UserMailer, nil, exception, "registration_by_admin_notification_email", anything)
+        UserMailer.registration_by_admin_notification_email(1).deliver
       end
     }
   end

--- a/spec/workers/user_registered_by_admin_sender_worker_spec.rb
+++ b/spec/workers/user_registered_by_admin_sender_worker_spec.rb
@@ -1,0 +1,32 @@
+# This file is part of Mconf-Web, a web application that provides access
+# to the Mconf webconferencing system. Copyright (C) 2010-2012 Mconf
+#
+# This file is licensed under the Affero General Public License version
+# 3 or later. See the LICENSE file.
+
+require 'spec_helper'
+
+describe UserRegisteredByAdminSenderWorker do
+  let(:worker) { UserRegisteredByAdminSenderWorker }
+
+  it "uses the queue :user_notifications" do
+    worker.instance_variable_get(:@queue).should eql(:user_notifications)
+  end
+
+  describe "#perform" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    context "for a user created by an admin" do
+      let(:activity) { RecentActivity.create(key: 'user.created_by_admin', trackable: user, notified: false) }
+
+      before {
+        worker.perform(activity.id)
+      }
+
+      it { UserMailer.should have_queue_size_of_at_least(1) }
+      it { UserMailer.should have_queued(:registration_by_admin_notification_email, user.id).in(:mailer) }
+      it { activity.reload.notified.should be(true) }
+    end
+  end
+
+end


### PR DESCRIPTION
Removed the unnecessary emails when a user is registered by an admin. Now when an admin register a new user, he will receive just one email announcing his new account.

refs #1469