### PR TITLE
Bug #871 - Use default error message 'Forgot password' screen form

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -73,7 +73,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # :http_auth and :token_auth by adding those symbols to the array below.

--- a/spec/features/devise/confirmation_instructions_spec.rb
+++ b/spec/features/devise/confirmation_instructions_spec.rb
@@ -77,8 +77,8 @@ feature "Confirmation instructions" do
         }.not_to send_email
       end
 
-      current_path.should eq(user_confirmation_path)
-      has_field_with_error "user_email"
+      current_path.should eq(new_user_session_path)
+      has_success_message
     end
 
     scenario "and the user doesn't exist" do
@@ -90,8 +90,8 @@ feature "Confirmation instructions" do
         }.not_to send_email
       end
 
-      current_path.should eq(user_confirmation_path)
-      has_field_with_error "user_email"
+      current_path.should eq(new_user_session_path)
+      has_success_message
     end
   end
 end

--- a/spec/features/visitor_logs_in_spec.rb
+++ b/spec/features/visitor_logs_in_spec.rb
@@ -146,7 +146,7 @@ feature 'Visitor logs in' do
     scenario 'when failed to request a new password (/users/password)' do
       visit new_user_password_path
       click_button "Request password"
-      expect(current_path).to eq("/users/password")
+      expect(current_path).to eq("/users/login")
 
       click_link 'Sign in'
       expect(current_path).to eq(login_path)
@@ -167,7 +167,7 @@ feature 'Visitor logs in' do
     scenario 'after a failed submit in the resend confirmation form (/users/confirmation)' do
       visit new_user_confirmation_path
       click_button 'Request confirmation email'
-      expect(current_path).to eq("/users/confirmation")
+      expect(current_path).to eq("/users/login")
 
       click_link 'Sign in'
       expect(current_path).to eq(login_path)


### PR DESCRIPTION
Activating this option, devise will have the same behave regardless if the email provided exists in database or not.

refs #871