### PR TITLE
Feature1153 - Allow admins to permanently remove users and spaces

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,6 +76,16 @@ class UsersController < ApplicationController
   end
 
   def destroy
+    @user.destroy
+    respond_to do |format|
+      format.html {
+        flash[:notice] = t('user.deleted')
+        redirect_to manage_users_path
+      }
+    end
+  end
+
+  def disable
     @user.disable
 
     if current_user == @user

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -104,7 +104,7 @@ module IconsHelper
   end
 
   def icon_delete(options={})
-    icon_constructor nil, "icon-awesome icon-remove-sign icon-mconf-delete", options
+    icon_constructor nil, "icon-awesome icon-trash icon-mconf-delete", options
   end
 
   def icon_disable(options={})

--- a/app/models/abilities/member_ability.rb
+++ b/app/models/abilities/member_ability.rb
@@ -7,7 +7,7 @@ module Abilities
       # Users
       # Disabled users are only visible to superusers
       can [:read, :fellows, :current, :select], User, disabled: false
-      can [:edit, :update, :destroy], User, id: user.id, disabled: false
+      can [:edit, :update, :disable], User, id: user.id, disabled: false
 
       # User profiles
       # Visible according to options selected by the user, editable by their owners

--- a/app/views/manage/_destroy_user.html.haml
+++ b/app/views/manage/_destroy_user.html.haml
@@ -1,0 +1,2 @@
+= link_to user_path(user), data: { confirm: t('.destroy_confirm') }, method: :delete do
+  = icon_delete(alt: t('.destroy'), title: t('.destroy'))

--- a/app/views/manage/_disabled_user.html.haml
+++ b/app/views/manage/_disabled_user.html.haml
@@ -4,7 +4,7 @@
 
   %ul.management-links
     = link_to enable_user_path(user), :data => { :confirm => t('.enable_confirm') }, :method => :post do
-      = icon_confirm(:alt => t('.enable'), :title => t('.enable'))
+      = icon_enable(:alt => t('.enable'), :title => t('.enable'))
 
   .user-text
     %span.user-name

--- a/app/views/manage/_enabled_user.html.haml
+++ b/app/views/manage/_enabled_user.html.haml
@@ -20,8 +20,9 @@
           = link_to approve_user_path(user), :method => :post, :data => { :confirm => t('.approve_confirm') } do
             = icon_approve(:alt => t('.approve'), :title => t('.approve'))
 
-      = link_to user_path(user), :data => { :confirm => t('.disable_confirm') }, :method => :delete do
-        = icon_delete(:alt => t('.disable'), :title => t('.disable'))
+      = link_to disable_user_path(user), :data => { :confirm => t('.disable_confirm') }, :method => :delete do
+        = icon_disable(:alt => t('.disable'), :title => t('.disable'))
+      = render 'manage/destroy_user', user: user
 
   .thread-title
     = link_to user_path(user), :class => 'user-name' do

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -78,8 +78,8 @@
               = icon_confirm_user(:alt => t('.confirm_user'))
               = t('.confirm_user')
         .input
-          = link_to user_path(@user), :data => { :confirm => t('.disable_confirm') }, :method => :delete do
-            = icon_delete(:alt => t('.disable'))
+          = link_to disable_user_path(@user), :data => { :confirm => t('.disable_confirm') }, :method => :delete do
+            = icon_disable(:alt => t('.disable'))
             = t('.disable')
 
   = f.button :wrapped, :cancel => edit_user_path(@user), :value => t("_other.save")
@@ -87,4 +87,4 @@
   - if current_user == @user
     #cancel-account.alert.alert-danger
       %span= t('.cancel_account')
-      = link_to t('.yes_cancel_account'), user_path(current_user), :data => { :confirm => t("are_you_sure") }, :method => :delete, :class => 'btn btn-small btn-danger'
+      = link_to t('.yes_cancel_account'), disable_user_path(current_user), :data => { :confirm => t("are_you_sure") }, :method => :delete, :class => 'btn btn-small btn-danger'

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -960,6 +960,9 @@ en:
     destroy_space:
       destroy: Delete space
       destroy_confirm: Are you sure you want to delete this space and all content associated with it? Unlike disabling the space this operation is irreversible!
+    destroy_user:
+      destroy: Delete user
+      destroy_confirm: Are you sure you want to delete this user and all content associated with it? Unlike disabling the user this operation is irreversible!
     spaces_list:
       filter_count_with_text: "Found %{count} spaces for filter \"%{value}\""
       filter_count_empty: "Found %{count} spaces"
@@ -1740,6 +1743,7 @@ en:
     category: Category
     confirm_password: "Confirm password"
     delete_from_space: "Delete user from space"
+    deleted: "User deleted"
     disable: "Disable user"
     disabled: "User %{username} disabled"
     email_used_to_create_account: "Enter the email address you used to create your account"

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -960,6 +960,9 @@ pt-br:
     destroy_space:
       destroy: Remover comunidade
       destroy_confirm: Tem certeza que deseja remover essa comunidade e todo conteúdo relacionado a ela? Diferente de desabilitar a comunidade essa operação é irreversível!
+    destroy_space:
+      destroy: Remover usuário
+      destroy_confirm: Tem certeza que deseja remover esse usuário e todo conteúdo relacionado a ele? Diferente de desabilitar o usuário essa operação é irreversível!
     spaces_list:
       filter_count_with_text: "%{count} comunidades encontradas para o filtro \"%{value}\""
       filter_count_empty: "%{count} comunidades encontradas"
@@ -1740,6 +1743,7 @@ pt-br:
     category: Categoria
     confirm_password: "Confirmar senha"
     delete_from_space: "Excluir usuário da comunidade"
+    deleted: "Usuário deletado"
     disable: "Desabilitar usuário"
     disabled: "Usuário %{username} desabilitado"
     email_used_to_create_account: "Digite o endereço de e-mail que você usou para criar a sua conta"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -140,6 +140,7 @@ Mconf::Application.routes.draw do
     end
 
     member do
+      delete :disable
       post :enable
       post :approve
       post :disapprove

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -351,12 +351,12 @@ describe UsersController do
     end
   end
 
-  describe "#destroy" do
+  describe "#disable" do
     let(:user) { FactoryGirl.create(:user) }
 
     context "an admin removing a user" do
       before(:each) { sign_in(FactoryGirl.create(:superuser)) }
-      before(:each) { delete :destroy, id: user.to_param }
+      before(:each) { delete :disable, id: user.to_param }
       it { should respond_with(:redirect) }
       it { should set_the_flash.to(I18n.t('user.disabled', username: user.username)) }
       it { should redirect_to(manage_users_path) }
@@ -365,7 +365,7 @@ describe UsersController do
 
     context "the user removing himself" do
       before(:each) { sign_in(user) }
-      before(:each) { delete :destroy, id: user.to_param }
+      before(:each) { delete :disable, id: user.to_param }
       it { should respond_with(:redirect) }
       it { should set_the_flash.to(I18n.t('devise.registrations.destroyed')) }
       it { should redirect_to(root_path) }
@@ -376,13 +376,13 @@ describe UsersController do
       let!(:user) { FactoryGirl.create(:user) }
       before {
         expect {
-          delete :destroy, id: user.to_param
+          delete :disable, id: user.to_param
         }.not_to change { User.count }
       }
       it { should redirect_to login_path }
     end
 
-    it { should_authorize an_instance_of(User), :destroy, via: :delete, id: user.to_param }
+    it { should_authorize an_instance_of(User), :disable, via: :delete, id: user.to_param }
   end
 
   describe "#enable" do

--- a/spec/features/manage/admin_manages_users_spec.rb
+++ b/spec/features/manage/admin_manages_users_spec.rb
@@ -148,7 +148,7 @@ def have_link_to_edit_user(user)
 end
 
 def have_link_to_disable_user(user)
-  have_css("a[href='#{user_path(user)}'][data-method='delete']")
+  have_css("a[href='#{disable_user_path(user)}'][data-method='delete']")
 end
 
 def have_link_to_confirm_user(user)

--- a/spec/features/manage/admin_manages_users_spec.rb
+++ b/spec/features/manage/admin_manages_users_spec.rb
@@ -23,6 +23,7 @@ describe 'Admin manages users' do
       before { visit manage_users_path }
 
       it { should have_css '.user-simple', :count => 7 }
+      it { should have_css '.icon-mconf-delete', :count => 4 }
       it { should have_css '.user-disabled', :count => 2 }
       it { should have_css '.icon-mconf-superuser', :count => 1 }
 
@@ -41,6 +42,7 @@ describe 'Admin manages users' do
         it { should have_css '.management-links' }
         it { should have_content t('_other.user.administrator') }
         it { should have_link_to_edit_user(user) }
+        it { should_not have_link_to_destroy_user(user) }
         it { should_not have_link_to_disable_user(user) }
         it { should_not have_link_to_confirm_user(user) }
       end
@@ -53,6 +55,7 @@ describe 'Admin manages users' do
         it { should have_css '.management-links' }
         it { should have_content t('_other.user.normal_user') }
         it { should have_link_to_edit_user(user) }
+        it { should have_link_to_destroy_user(user) }
         it { should have_link_to_disable_user(user) }
         it { should_not have_link_to_confirm_user(user) }
       end
@@ -64,6 +67,7 @@ describe 'Admin manages users' do
         it { should have_css '.management-links' }
         it { should have_link_to_enable_user(user) }
         it { should_not have_link_to_edit_user(user) }
+        it { should_not have_link_to_destroy_user(user) }
         it { should_not have_link_to_disable_user(user) }
         it { should_not have_link_to_confirm_user(user) }
       end
@@ -73,6 +77,7 @@ describe 'Admin manages users' do
         subject { page.find("#user-#{user.permalink}") }
 
         it { should have_link_to_edit_user(user) }
+        it { should have_link_to_destroy_user(user) }
         it { should have_link_to_disable_user(user) }
         it { should have_link_to_confirm_user(user) }
       end
@@ -90,6 +95,7 @@ describe 'Admin manages users' do
 
         it { should have_css '.management-links' }
         it { should have_link_to_disapprove_user(user) }
+        it { should have_link_to_destroy_user(user) }
       end
 
       context 'elements for an approved admin user' do
@@ -98,6 +104,7 @@ describe 'Admin manages users' do
 
         it { should have_css '.management-links' }
         it { should_not have_link_to_disapprove_user(user) }
+        it { should_not have_link_to_destroy_user(user) }
       end
 
       context 'elements for a unapproved user' do
@@ -106,6 +113,7 @@ describe 'Admin manages users' do
 
         it { should have_css '.management-links' }
         it { should have_link_to_edit_user(user) }
+        it { should have_link_to_destroy_user(user) }
         it { should_not have_link_to_disapprove_user(user) }
         it { should have_link_to_approve_user(user) }
         it { should have_content t('_other.user.unapproved_user') }
@@ -122,6 +130,7 @@ describe 'Admin manages users' do
 
         it { should have_css '.management-links' }
         it { should have_link_to_edit_user(user) }
+        it { should_not have_link_to_destroy_user(user) }
         it { should_not have_link_to_disapprove_user(user) }
         it { should have_css '.icon-mconf-superuser' }
         it { should have_content t('_other.user.administrator') }
@@ -133,6 +142,7 @@ describe 'Admin manages users' do
         subject { page.find("#user-#{user.permalink}") }
 
         it { should have_link_to_edit_user(user) }
+        it { should have_link_to_destroy_user(user) }
         it { should have_link_to_disable_user(user) }
         it { should have_link_to_confirm_user(user) }
         it { should_not have_link_to_disapprove_user(user) }
@@ -145,6 +155,10 @@ end
 
 def have_link_to_edit_user(user)
   have_link '', :href => edit_user_path(user)
+end
+
+def have_link_to_destroy_user(user)
+  have_css("a[href='#{user_path(user)}'][data-method='delete']")
 end
 
 def have_link_to_disable_user(user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -747,7 +747,7 @@ describe User do
     context "when is the user himself" do
       let(:user) { target }
       it {
-        allowed = [:read, :edit, :update, :destroy, :fellows, :current, :select]
+        allowed = [:read, :edit, :update, :disable, :fellows, :current, :select]
         should_not be_able_to_do_anything_to(target).except(allowed)
       }
 


### PR DESCRIPTION
The destroy method previously used to disable users in the system was moved to a new method called disable. Now the destroy method is used to fully remove an user from the system.

Changed the delete icon from 'icon-remove-sign' to 'icon-trash'.

Created tests for destroy method.

refs #1153