### PR TITLE
Remove destroy dependency from User to Post

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,7 +64,7 @@ class User < ActiveRecord::Base
   has_many :join_requests, :foreign_key => :candidate_id
   has_many :permissions, :dependent => :destroy
   has_one :profile, :dependent => :destroy
-  has_many :posts, :as => :author, :dependent => :destroy
+  has_many :posts, :as => :author
   has_one :bigbluebutton_room, :as => :owner, :dependent => :destroy
   has_one :ldap_token, :dependent => :destroy
   has_one :shib_token, :dependent => :destroy

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -24,7 +24,7 @@ describe User do
 
   it { should have_many(:permissions).dependent(:destroy) }
 
-  it { should have_many(:posts).dependent(:destroy) }
+  it { should have_many(:posts) }
 
   it { should validate_presence_of(:email) }
 


### PR DESCRIPTION
That way, it behaves exactly as if the user had been disabled: his posts still show
a link to his profile, which results in a 404 when clicked.

refs #1511