### PR TITLE
Bug #1547 - Form to invite people to a conference doesn't focus the right component and generates error

### DIFF
--- a/app/assets/javascripts/app/custom_bigbluebutton_rooms/_invitation_form.js.coffee
+++ b/app/assets/javascripts/app/custom_bigbluebutton_rooms/_invitation_form.js.coffee
@@ -61,6 +61,12 @@ class mconf.CustomBigbluebuttonRooms.Invitation
         results: (data, page) -> # parse the results into the format expected by Select2.
           results: data
 
+    # This option will open the select2 field to be ready to search
+    $(usersSelector).select2 'open'
+
+    # This option is optional. It was used just to improve the style of the page
+    $(usersSelector).select2 'focus'
+
     $(usersSelector).on "change", =>
       @checkRequired()
 

--- a/app/assets/javascripts/app/custom_bigbluebutton_rooms/_invitation_form.js.coffee
+++ b/app/assets/javascripts/app/custom_bigbluebutton_rooms/_invitation_form.js.coffee
@@ -61,7 +61,7 @@ class mconf.CustomBigbluebuttonRooms.Invitation
         results: (data, page) -> # parse the results into the format expected by Select2.
           results: data
 
-    # This option will open the select2 field to be ready to search
+    # This option will open the select2 field ready to search
     $(usersSelector).select2 'open'
 
     # This option is optional. It was used just to improve the style of the page

--- a/app/views/custom_bigbluebutton_rooms/_invitation_form.html.haml
+++ b/app/views/custom_bigbluebutton_rooms/_invitation_form.html.haml
@@ -11,7 +11,7 @@
         %span= t('.meeting_in')
         %span.meeting-url= join_webconf_url(room)
 
-      = f.input :users, :as => :string, :autofocus => true, :label => t('activerecord.attributes.invite.users')
+      = f.input :users, :as => :string, :label => t('activerecord.attributes.invite.users')
 
       -# TODO: it would be good to have a custom simple_form input for dates (see #1262)
       .invitation-dates


### PR DESCRIPTION
Fixed the form to invite people to a conference, now the right component is focused.

refs #1547