### PR TITLE
Bug #1546 - Error when a recent activity for a join request has an unexpected owner

### DIFF
--- a/app/workers/join_requests_worker.rb
+++ b/app/workers/join_requests_worker.rb
@@ -39,8 +39,8 @@ class JoinRequestsWorker
     requests = RecentActivity.where trackable_type: 'Space', key: ['space.accept', 'space.decline'], notified: [nil,false]
     requests = requests.all.reject do |req|
       jr = req.owner
-      # don't generate email for blank join requests and declined user requests
-      jr.blank? || (jr.is_request? && !jr.accepted?)
+      # don't generate email for blank join requests, declined user requests and if owner is not a join request
+      (jr.class.name != "JoinRequest") || jr.blank? || (jr.is_request? && !jr.accepted?)
     end
 
     requests.each do |activity|

--- a/db/migrate/20150416210956_recent_activity_remove_owner_from_space_join_options.rb
+++ b/db/migrate/20150416210956_recent_activity_remove_owner_from_space_join_options.rb
@@ -1,0 +1,17 @@
+class RecentActivityRemoveOwnerFromSpaceJoinOptions < ActiveRecord::Migration
+  def up
+    RecentActivity.where(key: ["space.accept", "space.decline"], owner_type: "Space").each do |ra|
+      ra.owner = nil
+      ra.notified = true
+      ra.save!
+    end
+  end
+
+  def down
+    RecentActivity.where(key: ["space.accept", "space.decline"], owner_type: "Space").each do |ra|
+      ra.owner = ra.trackable
+      ra.notified = false
+      ra.save!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150318204721) do
+ActiveRecord::Schema.define(version: 20150416210956) do
 
   create_table "activities", force: true do |t|
     t.integer  "trackable_id"
@@ -22,8 +22,8 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.text     "parameters"
     t.integer  "recipient_id"
     t.string   "recipient_type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
     t.boolean  "notified"
   end
 
@@ -51,8 +51,8 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.datetime "start_time"
     t.boolean  "running",      default: false
     t.boolean  "recorded",     default: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.integer  "creator_id"
     t.string   "creator_name"
   end
@@ -107,8 +107,8 @@ ActiveRecord::Schema.define(version: 20150318204721) do
   create_table "bigbluebutton_room_options", force: true do |t|
     t.integer  "room_id"
     t.string   "default_layout"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
     t.boolean  "presenter_share_only"
     t.boolean  "auto_start_video"
     t.boolean  "auto_start_audio"
@@ -165,6 +165,18 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.binary "data"
   end
 
+  create_table "institutions", force: true do |t|
+    t.string   "name"
+    t.string   "acronym"
+    t.string   "permalink"
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.integer  "user_limit"
+    t.integer  "can_record_limit"
+    t.text     "identifier"
+    t.boolean  "force_shib_login", default: false
+  end
+
   create_table "invitations", force: true do |t|
     t.integer  "target_id"
     t.string   "target_type"
@@ -196,8 +208,8 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.integer  "role_id"
     t.string   "email"
     t.boolean  "accepted"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
     t.datetime "processed_at"
     t.string   "secret_token"
   end
@@ -206,8 +218,8 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.integer  "user_id"
     t.string   "identifier"
     t.text     "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   add_index "ldap_tokens", ["identifier"], name: "index_ldap_tokens_on_identifier", unique: true, using: :btree
@@ -228,8 +240,8 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.float    "latitude",        limit: 24
     t.float    "longitude",       limit: 24
     t.string   "permalink"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
   end
 
   add_index "mweb_events_events", ["permalink"], name: "index_mweb_events_events_on_permalink", using: :btree
@@ -239,8 +251,8 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.string   "owner_type"
     t.integer  "event_id"
     t.string   "email"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "news", force: true do |t|
@@ -265,8 +277,8 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.integer  "subject_id",   null: false
     t.string   "subject_type", null: false
     t.integer  "role_id",      null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
   end
 
   create_table "posts", force: true do |t|
@@ -359,12 +371,12 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.string   "smtp_domain"
     t.string   "smtp_auth_type"
     t.string   "smtp_sender"
-    t.boolean  "chat_enabled",                   default: false
-    t.string   "xmpp_server"
     t.text     "shib_env_variables"
     t.string   "shib_login_field"
     t.string   "timezone",                       default: "UTC"
     t.string   "external_help"
+    t.boolean  "chat_enabled",                   default: false
+    t.string   "xmpp_server"
     t.boolean  "webconf_auto_record",            default: false
     t.boolean  "ldap_enabled"
     t.string   "ldap_host"
@@ -382,20 +394,22 @@ ActiveRecord::Schema.define(version: 20150318204721) do
     t.string   "ldap_filter"
     t.boolean  "shib_always_new_account",        default: false
     t.boolean  "local_auth_enabled",             default: true
+    t.string   "ldap_principal_name_field"
     t.string   "visible_locales",                default: "---\n- en\n- pt-br\n"
   end
 
   create_table "spaces", force: true do |t|
     t.string   "name"
     t.boolean  "deleted"
-    t.boolean  "public",      default: false
+    t.boolean  "public",         default: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "description"
     t.string   "permalink"
-    t.boolean  "disabled",    default: false
-    t.boolean  "repository",  default: false
+    t.boolean  "disabled",       default: false
+    t.boolean  "repository",     default: false
     t.string   "logo_image"
+    t.integer  "institution_id"
   end
 
   create_table "users", force: true do |t|


### PR DESCRIPTION
Fix to don't let workers break if the owner is not a "JoinRequest".
Migration to fix recent activities with wrong owners.

refs #1546