### PR TITLE
Feature #1513 - Admins should always be moderators in all web conference rooms

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -108,16 +108,15 @@ class ApplicationController < ActionController::Base
         guest_role
       end
     else
-      if current_user.superuser? && !room.is_running?
+      # Superusers has the right to create and be moderator in any room
+      if current_user.superuser?
         :moderator
       elsif room.owner_type == "User"
         if room.owner.id == current_user.id
           # only the owner is moderator
           :moderator
         else
-          if current_user.superuser?
-            :attendee
-          elsif room.private
+          if room.private
             :key # ask for a password if room is private
           else
             guest_role
@@ -135,9 +134,7 @@ class ApplicationController < ActionController::Base
             :attendee
           end
         else
-          if current_user.superuser?
-            :attendee
-          elsif room.private
+          if room.private
             :key
           else
             guest_role

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -79,7 +79,7 @@ describe ApplicationController do
             BigbluebuttonRoom.any_instance.stub(:is_running?).and_return(true)
           }
           before(:each) { get :index, :room_id => room.id }
-          it { assigns(:result).should eql(:attendee) }
+          it { assigns(:result).should eql(:moderator) }
         end
 
         context "and the user is not the owner but is a superuser and the room is not running" do
@@ -121,7 +121,7 @@ describe ApplicationController do
             BigbluebuttonRoom.any_instance.stub(:is_running?).and_return(true)
           }
           before(:each) { get :index, :room_id => room.id }
-          it { assigns(:result).should eql(:attendee) }
+          it { assigns(:result).should eql(:moderator) }
         end
 
         context "and the user is not the owner but is a superuser and the room is not running" do
@@ -243,7 +243,7 @@ describe ApplicationController do
             BigbluebuttonRoom.any_instance.stub(:is_running?).and_return(true)
           }
           before(:each) { get :index, :room_id => room.id }
-          it { assigns(:result).should eql(:attendee) }
+          it { assigns(:result).should eql(:moderator) }
         end
 
         context "and the user is not a member of the space but is a superuser and the room is not running" do
@@ -322,7 +322,7 @@ describe ApplicationController do
             BigbluebuttonRoom.any_instance.stub(:is_running?).and_return(true)
           }
           before(:each) { get :index, :room_id => room.id }
-          it { assigns(:result).should eql(:attendee) }
+          it { assigns(:result).should eql(:moderator) }
         end
 
         context "and the user is not a member of the space but is a superuser and the room is not running" do


### PR DESCRIPTION
Modifications to let admins create conferences in any room and be moderator in any room who they join.

refs #1513