### PR TITLE
Feature 1552 - Allow admins to remove users from spaces

### DIFF
--- a/app/assets/stylesheets/app/application/base.css.scss
+++ b/app/assets/stylesheets/app/application/base.css.scss
@@ -202,7 +202,7 @@ form {
   &.user-detailed {
     .user-text { float: left; }
     .user-divider { float: left; margin-left: 5px; margin-right: 5px; color: $gray; }
-    .user-name { display: block; clear: both; }
+    .user-name { display: block; clear: both; float: left; }
     .user-mail { display: block; clear: both; }
     .user-info-prefix { color: $font-color-gray; float: left; margin-right: 5px; }
     .user-organization { float: left; }

--- a/app/assets/stylesheets/app/application/base.css.scss
+++ b/app/assets/stylesheets/app/application/base.css.scss
@@ -207,6 +207,7 @@ form {
     .user-info-prefix { color: $font-color-gray; float: left; margin-right: 5px; }
     .user-organization { float: left; }
     .user-location { float: left; }
+    .user-remove { float: right; }
   }
 }
 

--- a/app/models/abilities/member_ability.rb
+++ b/app/models/abilities/member_ability.rb
@@ -47,8 +47,11 @@ module Abilities
       # Spaces
       can [:create, :select], Space
       can [:read, :webconference, :recordings], Space, public: true
-      can [:read, :webconference, :recordings, :leave], Space do |space|
+      can [:read, :webconference, :recordings], Space do |space|
         space.users.include?(user)
+      end
+      can [:leave], Space do |space|
+        space.users.include?(user) && !space.is_last_admin?(user)
       end
       # Only the admin can disable or update information on a space
       # Only global admins can destroy spaces

--- a/app/models/abilities/member_ability.rb
+++ b/app/models/abilities/member_ability.rb
@@ -127,7 +127,7 @@ module Abilities
 
       # Permissions
       # Only space admins can update user roles/permissions
-      can [:read, :edit, :update], Permission do |perm|
+      can [:read, :edit, :update, :destroy], Permission do |perm|
         case perm.subject_type
         when "Space"
           admins = perm.subject.admins

--- a/app/models/abilities/superuser_ability.rb
+++ b/app/models/abilities/superuser_ability.rb
@@ -10,7 +10,20 @@ module Abilities
     # TODO: restrict a bit what superusers can do
     def register_abilities(user)
       can :manage, :all
+
+      cannot [:leave], Space do |space|
+        space.users.include?(user) && space.users.count == 1
+      end
+
+      cannot [:destroy], Permission do |perm|
+        cant = false
+        if perm.subject_type == "Space"
+          # A Superuser can't remove the last admin.
+          s = perm.subject
+          cant = s.is_last_admin?(perm.user)
+        end
+        cant
+      end
     end
   end
-
 end

--- a/app/views/spaces/_sidebar.html.haml
+++ b/app/views/spaces/_sidebar.html.haml
@@ -43,5 +43,5 @@
         - @space.admins.each do |user|
           = render :partial => 'users/simple_user', :locals => { :user => user }
 
-    - if user_signed_in? && @space.users.include?(current_user) && !(@space.is_last_admin?(current_user))
+    - if user_signed_in? && can?(:leave, @space)
       = render :partial => 'spaces/sidebar_leave_space'

--- a/app/views/users/_detailed_user.html.haml
+++ b/app/views/users/_detailed_user.html.haml
@@ -21,7 +21,7 @@
       - unless user.location.blank?
         %span.user-location= sanitize(user.location)
 
-      - perm = Permission.where(user: user, subject: @space).first
-      - if can?(:destroy, perm)
-        - params = { :method => :delete, :class => 'btn btn-mini btn-danger', :data => { :confirm => t('space.remove_user.confirm') } }
-        = link_to t('space.remove_user.remove'), permission_path(perm), params
+    - perm = Permission.where(user: user, subject: @space).first
+    - if can?(:destroy, perm)
+      - params = { :method => :delete, :class => 'btn btn-mini btn-danger', :data => { :confirm => t('space.remove_user.confirm') } }
+      %span.user-remove= link_to t('space.remove_user.remove'), permission_path(perm), params

--- a/app/views/users/_detailed_user.html.haml
+++ b/app/views/users/_detailed_user.html.haml
@@ -23,5 +23,14 @@
 
     - perm = Permission.where(user: user, subject: @space).first
     - if can?(:destroy, perm)
-      - params = { :method => :delete, :class => 'btn btn-mini btn-danger', :data => { :confirm => t('space.remove_user.confirm') } }
-      %span.user-remove= link_to t('space.remove_user.remove'), permission_path(perm), params
+      - if user == current_user
+        -# Use link to leave space if the user show is the current user
+        -# This already handles cases where the user loses the ability to 'show'
+        -# the space to which he belonged and must be redirected to the root.
+        - link = leave_space_path(@space)
+        - params = { method: :post, class: 'btn btn-mini btn-danger', data: { confirm: t('space.confirm') } }
+        %span.user-remove= link_to t('space.leave.leave_this_space'), link, options_for_tooltip(t("tooltip.leave_space"), params)
+      - else
+        -# Otherwise, use a 'delete' with the Permission
+        - params= { method: :delete, class: 'btn btn-mini btn-danger', data: { confirm: t('space.remove_user.confirm') } }
+        %span.user-remove= link_to t('space.remove_user.remove'), permission_path(perm), params

--- a/app/views/users/_detailed_user.html.haml
+++ b/app/views/users/_detailed_user.html.haml
@@ -20,7 +20,8 @@
 
       - unless user.location.blank?
         %span.user-location= sanitize(user.location)
+
       - perm = Permission.where(user: user, subject: @space).first
       - if can?(:destroy, perm)
-        - params = { :method => :delete, :class => 'btn btn-mini btn-danger', :data => { :confirm => t('space.confirm') } }
-        = link_to "Remove user", permission_path(perm), params
+        - params = { :method => :delete, :class => 'btn btn-mini btn-danger', :data => { :confirm => t('space.remove_user.confirm') } }
+        = link_to t('space.remove_user.remove'), permission_path(perm), params

--- a/app/views/users/_detailed_user.html.haml
+++ b/app/views/users/_detailed_user.html.haml
@@ -27,10 +27,11 @@
         -# Use link to leave space if the user show is the current user
         -# This already handles cases where the user loses the ability to 'show'
         -# the space to which he belonged and must be redirected to the root.
-        - link = leave_space_path(@space)
-        - params = { method: :post, class: 'btn btn-mini btn-danger', data: { confirm: t('space.confirm') } }
-        %span.user-remove= link_to t('space.leave.leave_this_space'), link, options_for_tooltip(t("tooltip.leave_space"), params)
+        - if can?(:leave, @space)
+          - link = leave_space_path(@space)
+          - params = { method: :post, class: 'btn btn-mini btn-danger', data: { confirm: t('space.confirm') } }
+          %span.user-remove= link_to t('space.leave.leave_this_space'), link, options_for_tooltip(t("tooltip.leave_space"), params)
       - else
         -# Otherwise, use a 'delete' with the Permission
-        - params= { method: :delete, class: 'btn btn-mini btn-danger', data: { confirm: t('space.remove_user.confirm') } }
+        - params = { method: :delete, class: 'btn btn-mini btn-danger', data: { confirm: t('space.remove_user.confirm') } }
         %span.user-remove= link_to t('space.remove_user.remove'), permission_path(perm), params

--- a/app/views/users/_detailed_user.html.haml
+++ b/app/views/users/_detailed_user.html.haml
@@ -20,3 +20,7 @@
 
       - unless user.location.blank?
         %span.user-location= sanitize(user.location)
+      - perm = Permission.where(user: user, subject: @space).first
+      - if can?(:destroy, perm)
+        - params = { :method => :delete, :class => 'btn btn-mini btn-danger', :data => { :confirm => t('space.confirm') } }
+        = link_to "Remove user", permission_path(perm), params

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -1476,6 +1476,9 @@ en:
     public: 
       one: "Public space"
       other: "Public spaces"
+    remove_user:
+      confirm: "Are you sure you want to remove this user from the space?"
+      remove: "Remove user"
     select: Spaces
     show: "Show spaces:"
     show_all: "Show all spaces"

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -1477,6 +1477,9 @@ pt-br:
     public:
       one: "Comunidade pública"
       other: "Comunidades públicas"
+    remove_user:
+      confirm: "Tem certeza de que deseja remover este usuário da comunidade?"
+      remove: "Remover usuário"
     select: Comunidades
     show: "Mostrar comunidades:"
     show_all: "Mostrar todas as comunidades"

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -81,7 +81,7 @@ describe Permission do
           end
         }
         let(:ability_check) {
-          should_not be_able_to_do_anything_to(target).except([:read, :edit, :update])
+          should_not be_able_to_do_anything_to(target).except([:read, :edit, :update, :destroy])
         }
         it_should_behave_like "for all permission types"
       end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -980,14 +980,28 @@ describe Space do
         context "he is a member of" do
           context "with the role 'Admin'" do
             before { target.add_member!(user, "Admin") }
-            it {
-              list = [
-                :read, :webconference, :recordings, :create, :select, :leave, :edit,
-                :update, :update_logo, :disable, :user_permissions, :edit_recording,
-                :webconference_options, :index_join_requests, :index_news
-              ]
-              should_not be_able_to_do_anything_to(target).except(list)
-            }
+            context "being the last Admin" do
+              it {
+                # The last Admin can't leave
+                list = [
+                  :read, :webconference, :recordings, :create, :select, :edit,
+                  :update, :update_logo, :disable, :user_permissions, :edit_recording,
+                  :webconference_options, :index_join_requests, :index_news
+                ]
+                should_not be_able_to_do_anything_to(target).except(list)
+              }
+            end
+            context "when there's another Admin" do
+              before { target.add_member!(FactoryGirl.create(:user), "Admin") }
+              it {
+                list = [
+                  :read, :webconference, :recordings, :create, :select, :leave, :edit,
+                  :update, :update_logo, :disable, :user_permissions, :edit_recording,
+                  :webconference_options, :index_join_requests, :index_news
+                ]
+                should_not be_able_to_do_anything_to(target).except(list)
+              }
+            end
           end
 
           context "with the role 'User'" do
@@ -1012,14 +1026,28 @@ describe Space do
         context "he is a member of" do
           context "with the role 'Admin'" do
             before { target.add_member!(user, "Admin") }
-            it {
-              list = [
-                :read, :webconference, :recordings, :create, :select, :leave, :edit,
-                :update, :update_logo, :disable, :user_permissions, :edit_recording,
-                :webconference_options, :index_join_requests, :index_news
-              ]
-              should_not be_able_to_do_anything_to(target).except(list)
-            }
+            context "being the last Admin" do
+              it {
+                # The last Admin can't leave
+                list = [
+                  :read, :webconference, :recordings, :create, :select, :edit,
+                  :update, :update_logo, :disable, :user_permissions, :edit_recording,
+                  :webconference_options, :index_join_requests, :index_news
+                ]
+                should_not be_able_to_do_anything_to(target).except(list)
+              }
+            end
+            context "when there's another Admin" do
+              before { target.add_member!(FactoryGirl.create(:user), "Admin") }
+              it {
+                list = [
+                  :read, :webconference, :recordings, :create, :select, :leave, :edit,
+                  :update, :update_logo, :disable, :user_permissions, :edit_recording,
+                  :webconference_options, :index_join_requests, :index_news
+                ]
+                should_not be_able_to_do_anything_to(target).except(list)
+              }
+            end
           end
 
           context "with the role 'User'" do


### PR DESCRIPTION
Changed the Abilities so that both global and space admins are now able to
remove users.
A user will not be able for removal if it's the last admin of that space.