### PR TITLE
1604: Allow global admins to add users to a space without the user having to accept it

### DIFF
--- a/app/assets/javascripts/app/join_requests/create_no_accept.js.coffee
+++ b/app/assets/javascripts/app/join_requests/create_no_accept.js.coffee
@@ -1,0 +1,30 @@
+$ ->
+  if isOnPage 'join_requests', 'create_no_accept'
+
+    id = '#candidates'
+    url = '/users/select?limit=10'
+
+    $(id).select2
+      minimumInputLength: 1
+      width: 'resolve'
+      multiple: true
+      formatSearching: -> I18n.t('join_requests.create_no_accept.users.searching')
+      formatInputTooShort: -> I18n.t('join_requests.create_no_accept.users.hint')
+      formatNoMatches: -> I18n.t('join_requests.create_no_accept.users.no_results')
+      tags: true
+      tokenSeparators: [",",";"]
+
+      formatSelection: (object, container) ->
+        text = if object.name?
+          object.name
+        else
+          object.text
+        mconf.Base.escapeHTML(text)
+
+      ajax:
+        url: url
+        dataType: "json"
+        data: (term, page) ->
+          q: term # search term
+        results: (data, page) -> # parse the results into the format expected by Select2.
+          results: data

--- a/app/controllers/join_requests_controller.rb
+++ b/app/controllers/join_requests_controller.rb
@@ -206,10 +206,11 @@ class JoinRequestsController < ApplicationController
     ids.each do |id|
       user = User.find_by_id(id)
       if @space.pending_join_request_or_invitation_for?(user)
-        # Update the existing join request.
+        # Destroy old join request
         old_jr = @space.pending_join_request_or_invitation_for(user)
-
         old_jr.destroy
+
+        # Create a new one corresponding to this addition
         jr = @space.join_requests.new(join_request_params)
         jr.candidate = user
         jr.email = user.email

--- a/app/controllers/join_requests_controller.rb
+++ b/app/controllers/join_requests_controller.rb
@@ -236,6 +236,7 @@ class JoinRequestsController < ApplicationController
         jr.request_type = JoinRequest::TYPES[:no_accept]
         jr.introducer = current_user
         jr.accepted = true
+        jr.processed = true
 
         if jr.save
           success.push jr.candidate.username

--- a/app/controllers/join_requests_controller.rb
+++ b/app/controllers/join_requests_controller.rb
@@ -209,12 +209,14 @@ class JoinRequestsController < ApplicationController
         # Update the existing join request.
         old_jr = @space.pending_join_request_or_invitation_for(user)
 
-        old_jr.request_type = JoinRequest::TYPES[:no_accept]
-        old_jr.introducer = current_user
-        old_jr.accepted = true
-        old_jr.role_id = join_request_params[:role_id]
-
-        if old_jr.save
+        old_jr.destroy
+        jr = @space.join_requests.new(join_request_params)
+        jr.candidate = user
+        jr.email = user.email
+        jr.request_type = JoinRequest::TYPES[:no_accept]
+        jr.introducer = current_user
+        jr.accepted = true
+        if jr.save
           success.push old_jr.candidate.username
         else
           errors.push "#{old_jr.email}: #{old_jr.errors.full_messages.join(', ')}"

--- a/app/controllers/join_requests_controller.rb
+++ b/app/controllers/join_requests_controller.rb
@@ -207,13 +207,14 @@ class JoinRequestsController < ApplicationController
       user = User.find_by_id(id)
       # New JoinRequest corresponding to this addition
       jr = @space.join_requests.new(join_request_params)
-
-      jr.candidate = user
-      jr.email = user.email
-      jr.request_type = JoinRequest::TYPES[:no_accept]
-      jr.introducer = current_user
-      jr.accepted = true
-      jr.processed = true
+      if user
+        jr.candidate = user
+        jr.email = user.email
+        jr.request_type = JoinRequest::TYPES[:no_accept]
+        jr.introducer = current_user
+        jr.accepted = true
+        jr.processed = true
+      end
 
       if @space.pending_join_request_or_invitation_for?(user)
         # Need to mark the old JoinRequest as processed to avoid

--- a/app/mailers/space_mailer.rb
+++ b/app/mailers/space_mailer.rb
@@ -36,6 +36,19 @@ class SpaceMailer < BaseMailer
     end
   end
 
+  def join_no_accept_email(jr_id)
+    jr = JoinRequest.find(jr_id)
+    @introducer = jr.introducer
+    @space = jr.group
+
+    locale = get_user_locale(jr.candidate, false)
+    I18n.with_locale(locale) do
+      subject = t("space_mailer.join_no_accept_email.subject",
+                  space: @space.name, username: @introducer.full_name).html_safe
+      create_email(jr.email, @introducer.email, subject)
+    end
+  end
+
   def join_request_email(jr_id, receiver_id)
     @join_request = JoinRequest.find(jr_id)
     receiver = User.find(receiver_id)

--- a/app/mailers/views/space_mailer/join_no_accept_email.html.haml
+++ b/app/mailers/views/space_mailer/join_no_accept_email.html.haml
@@ -1,0 +1,4 @@
+#join-no-accept-email
+  %p= t('.message.header', sender: @introducer.full_name, email_sender: @introducer.email, space: @space.name).html_safe
+
+  %p= t('.message.link', space_url: space_url(@space, host: Site.current.domain)).html_safe

--- a/app/models/join_request.rb
+++ b/app/models/join_request.rb
@@ -9,6 +9,7 @@ class JoinRequest < ActiveRecord::Base
 
   TYPES = {
     invite: "invite",
+    no_accept: "no_accept",
     request: "request"
   }
 

--- a/app/views/join_requests/create_no_accept.html.haml
+++ b/app/views/join_requests/create_no_accept.html.haml
@@ -1,0 +1,21 @@
+- page_title t('spaces.admin_tabs.invite'), :in => @space.name
+
+- spaces_menu_at :admin
+= render partial: 'spaces/menu'
+
+- spaces_admin_menu_at :create_no_accept
+= render partial: 'spaces/admin_tabs'
+
+#space-invitation
+  %h3= t('.title')
+
+  = simple_form_for @join_request, url: space_join_requests_path(create_no_accept: true), html: { class: 'single-column' } do |f|
+    .input
+      %label= t('.candidates')
+      = text_field_tag :candidates, '', autofocus: true, class: 'string'
+    .input
+      %label= t('.role_label')
+      - roles = Space.roles.map { |r| [ r.translated_name, r.id ] }
+      = select "join_request", "role_id", roles, selected: default_role.id
+
+    = f.button :wrapped, value: t("button.send")

--- a/app/views/public_activity/_join_request.html.haml
+++ b/app/views/public_activity/_join_request.html.haml
@@ -25,7 +25,11 @@
       - if activity.parameters.has_key?(:introducer_id) and activity.parameters.has_key?(:introducer)
         - name = activity.parameters[:introducer]
         - link = user_path_from_id(activity.parameters[:introducer_id])
-        = activity_translate("join_request.invite_with_introducer", introducer: name, introducer_url: link)
+        - if !activity.trackable.nil? and activity.trackable_type == 'JoinRequest' and
+          - activity.trackable.request_type == JoinRequest::TYPES[:no_accept]
+          = activity_translate("join_request.no_accept", introducer: name, introducer_url: link)
+        - else
+          = activity_translate("join_request.invite_with_introducer", introducer: name, introducer_url: link)
       - else
         = activity_translate(activity.key)
       = link_to_trackable activity.trackable, activity.trackable_type

--- a/app/views/spaces/_admin_tabs.html.haml
+++ b/app/views/spaces/_admin_tabs.html.haml
@@ -6,4 +6,5 @@
     = link_to t('.admissions'), space_join_requests_path(@space), spaces_admin_menu_select_if(:admissions, :class => "btn btn-small")
     = link_to t('.users'), user_permissions_space_path(@space), spaces_admin_menu_select_if(:users, :class => "btn btn-small")
     = link_to t('.webconf_options'), webconference_options_space_path(@space), spaces_admin_menu_select_if(:webconference_options, :class => "btn btn-small")
-    = link_to t('.add_member'), create_no_accept_space_join_requests_path(@space), spaces_admin_menu_select_if(:create_no_accept, :class => "btn btn-small")
+    - if can?(:add_no_accept, @space)
+      = link_to t('.add_member'), create_no_accept_space_join_requests_path(@space), spaces_admin_menu_select_if(:create_no_accept, :class => "btn btn-small")

--- a/app/views/spaces/_admin_tabs.html.haml
+++ b/app/views/spaces/_admin_tabs.html.haml
@@ -6,3 +6,4 @@
     = link_to t('.admissions'), space_join_requests_path(@space), spaces_admin_menu_select_if(:admissions, :class => "btn btn-small")
     = link_to t('.users'), user_permissions_space_path(@space), spaces_admin_menu_select_if(:users, :class => "btn btn-small")
     = link_to t('.webconf_options'), webconference_options_space_path(@space), spaces_admin_menu_select_if(:webconference_options, :class => "btn btn-small")
+    = link_to t('.add_member'), create_no_accept_space_join_requests_path(@space), spaces_admin_menu_select_if(:create_no_accept, :class => "btn btn-small")

--- a/app/workers/join_request_no_accept_sender_worker.rb
+++ b/app/workers/join_request_no_accept_sender_worker.rb
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+# This file is part of Mconf-Web, a web application that provides access
+# to the Mconf webconferencing system. Copyright (C) 2010-2015 Mconf.
+#
+# This file is licensed under the Affero General Public License version
+# 3 or later. See the LICENSE file.
+
+class JoinRequestNoAcceptSenderWorker < BaseWorker
+  @queue = :join_requests
+
+  def self.perform(activity_id)
+    activity = RecentActivity.find(activity_id)
+    join_request = activity.trackable
+
+    return if activity.notified
+
+    if join_request.nil?
+      Resque.logger.info "Invalid join request in a recent activity item: #{activity.inspect}"
+    else
+      Resque.logger.info "Sending join request no accept notification: #{join_request.inspect}"
+      SpaceMailer.join_no_accept_email(join_request.id).deliver
+    end
+
+    activity.notified = true
+    activity.save!
+  end
+end

--- a/app/workers/join_requests_worker.rb
+++ b/app/workers/join_requests_worker.rb
@@ -13,6 +13,7 @@ class JoinRequestsWorker < BaseWorker
     request_notifications
     invite_notifications
     processed_request_notifications
+    join_no_accept_notifications
   end
 
   # Goes through all activities for join requests created by admins inviting users to join a space
@@ -49,4 +50,11 @@ class JoinRequestsWorker < BaseWorker
     end
   end
 
+  def self.join_no_accept_notifications
+    joins = RecentActivity.where trackable_type: 'JoinRequest', key: ['join_request.no_accept'], notified: [nil, false]
+
+    joins.each do |activity|
+      Resque.enqueue(JoinRequestNoAcceptSenderWorker, activity.id)
+    end
+  end
 end

--- a/config/locales/en/_mailer.yml
+++ b/config/locales/en/_mailer.yml
@@ -46,6 +46,11 @@ en:
         link: "You accept or decline this invitation clicking by clicking the link: <br/> <a href=\"%{url}\">%{url}</a><br/><br/>You can find more information about this space in the page: <br/><a href=\"%{space_url}\">%{space_url}</a>"
         user_message: "This is the message written by %{sender}:"
       subject: "%{username} invited you to join the space %{space}"
+    join_no_accept_email:
+      message:
+        header: "You have been added by <b>%{sender}</b> (%{email_sender}) to the space <b>%{space}</b>."
+        link: "You can view the space you've been added to by clicking the link: <br/> <a href=\"%{space_url}\">%{space_url}</a>"
+      subject: "%{username} added you to the space %{space}"
     join_request_email:
       message:
         header: "<b>%{candidate}</b> wants to join the space <b>%{space}</b>, that is administered by you."

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -809,6 +809,14 @@ en:
       error: "Something went wrong when processing your request, please try again. (details: %{errors})"
       sent: "Your invitation was successfully sent to: %{users}"
       user_not_found: "User not found: %{id}"
+    create_no_accept:
+      candidates: "Search users to add"
+      role_label: "Role for the users added"
+      title: "Add users to the space"
+      users:
+        hint: "Type to start searching"
+        no_results: "No results found"
+        searching: "Searching..."
     decline:
       declined: "Join request declined"
       invitation_destroyed: "Invitation successfully cancelled"
@@ -1531,6 +1539,7 @@ en:
       news: "News"
       users: "Users"
       webconf_options: "Webconference options"
+      add_member: "Add member"
     edit:
       change_logo: "Change picture"
       delete_confirmation: "Are you sure? This space will be inaccessible to you and to all the other users!"

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -16,6 +16,7 @@ en:
       deleted: that has since been deleted
       invite_html: "was invited to join the space"
       invite_with_introducer_html: "was invited by <a href=\"%{introducer_url}\">%{introducer}</a> to join the space"
+      no_accept_html: "was added by <a href=\"%{introducer_url}\">%{introducer}</a> to the space"
       request_html: "has requested to join the space"
     mweb_events_event:
       create_html: created the event %{name} in the space

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -1541,7 +1541,7 @@ en:
       news: "News"
       users: "Users"
       webconf_options: "Webconference options"
-      add_member: "Add member"
+      add_member: "Add members"
     edit:
       change_logo: "Change picture"
       delete_confirmation: "Are you sure? This space will be inaccessible to you and to all the other users!"

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -811,6 +811,7 @@ en:
       user_not_found: "User not found: %{id}"
     create_no_accept:
       candidates: "Search users to add"
+      created: "You have successfully added the users %{users} to this space"
       role_label: "Role for the users added"
       title: "Add users to the space"
       users:

--- a/config/locales/pt-br/_mailer.yml
+++ b/config/locales/pt-br/_mailer.yml
@@ -46,6 +46,11 @@ pt-br:
         link: "Você pode aceitar ou recusar o convite clicando no link: <br/><a href=\"%{url}\">%{url}</a><br/><br/>Você pode encontrar mais informações sobre esta comunidade na página: <br/><a href=\"%{space_url}\">%{space_url}</a>"
         user_message: "Esta é a mensagem escrita por %{sender}:"
       subject: "%{username} convidou você para participar da comunidade %{space}"
+    join_no_accept_email:
+      message:
+        header: "Você foi adicionado por <b>%{sender}</b> (%{email_sender}) à comunidade <b>%{space}</b>."
+        link: "Você pode visualizar a comunidade à qual você foi adicionado clicando no link: <br/> <a href=\"%{space_url}\">%{space_url}</a>"
+      subject: "%{username} adicionou você à comunidade %{space}" 
     join_request_email:
       message:
         header: "<b>%{candidate}</b> quer participar da comunidade <b>%{space}</b>, que você administra."

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -16,6 +16,7 @@ pt-br:
       deleted: que não existe mais
       invite_html: "foi convidado(a) para entrar na comunidade"
       invite_with_introducer_html: "foi convidado(a) por <a href=\"%{introducer_url}\">%{introducer}</a> para entrar na comunidade"
+      no_accept_html: "foi adicionado por <a href=\"%{introducer_url}\">%{introducer}</a> à comunidade"
       request_html: "requisitou ingresso na comunidade"
     mweb_events_event:
       create_html: criou o evento %{name} na comunidade
@@ -809,6 +810,15 @@ pt-br:
       error: "Algo errado aconteceu ao processar sua requisição, por favor tente novamente. (detalhes: %{errors})"
       sent: "Seu convite foi enviado com sucesso para: %{users}"
       user_not_found: "Usuário não encontrado: %{id}"
+    create_no_accept:
+      candidates: "Procure usuários para adicionar"
+      created: "Você adicionou os usuários %{users} à comunidade com sucesso"
+      role_label: "Papel dos usuários adicionados"
+      title: "Adicionar usuários à comunidade"
+      users:
+        hint: "Digite para começar a buscar"
+        no_results: "Nenhum resultado encontrado"
+        searching: "Procurando..."
     decline:
       declined: "Pedido de adesão negado"
       invitation_destroyed: "Convite cancelado com sucesso"
@@ -1526,6 +1536,7 @@ pt-br:
       today: "Não existem eventos para hoje"
   spaces: 
     admin_tabs:
+      add_member: "Adicionar membros"
       admissions: "Admissões"
       general_options: "Opções gerais"
       invite: "Convidar pessoas"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -113,6 +113,7 @@ Mconf::Application.routes.draw do
     resources :join_requests, only: [:index, :show, :new, :create] do
       collection do
         get :invite
+        get :create_no_accept
       end
 
       member do


### PR DESCRIPTION
Add functionality so that Global Admins can add users to the spaces.

Deals with cases where there already was a pending Join Request from the user
being added on the space he's being added to.

This new mode of adding users to spaces was called a Join Request "no_accept",
since the user doesn't have to accept it, he's just added to the space. Maybe
the name is not the best, but I didn't want to call it "force_add" or something like that.