### PR TITLE
When a user is created by shibboleth, the activity is only created af…

### DIFF
--- a/app/controllers/shibboleth_controller.rb
+++ b/app/controllers/shibboleth_controller.rb
@@ -158,6 +158,7 @@ class ShibbolethController < ApplicationController
         logger.info "Shibboleth: created a new account: #{user.inspect}"
         token.data = shib.get_data
         token.save! # TODO: what if it fails
+        create_notification(token.user, token)
         flash[:success] = t('shibboleth.create_association.account_created', url: new_user_password_path).html_safe
       else
         logger.info "Shibboleth: error saving the new user created: #{user.errors.full_messages}"
@@ -220,6 +221,12 @@ class ShibbolethController < ApplicationController
   def get_always_new_account
     return current_site.shib_always_new_account
   end
+
+   def create_notification(user, token)
+      RecentActivity.create(
+        key: 'shibboleth.user.created', owner: token, trackable: user, notified: false
+      )
+    end
 
   # Adds fake test data to the environment to test shibboleth in development.
   def test_data

--- a/app/controllers/shibboleth_controller.rb
+++ b/app/controllers/shibboleth_controller.rb
@@ -158,7 +158,7 @@ class ShibbolethController < ApplicationController
         logger.info "Shibboleth: created a new account: #{user.inspect}"
         token.data = shib.get_data
         token.save! # TODO: what if it fails
-        create_notification(token.user, token)
+        shib.create_notification(token.user, token)
         flash[:success] = t('shibboleth.create_association.account_created', url: new_user_password_path).html_safe
       else
         logger.info "Shibboleth: error saving the new user created: #{user.errors.full_messages}"
@@ -221,12 +221,6 @@ class ShibbolethController < ApplicationController
   def get_always_new_account
     return current_site.shib_always_new_account
   end
-
-   def create_notification(user, token)
-      RecentActivity.create(
-        key: 'shibboleth.user.created', owner: token, trackable: user, notified: false
-      )
-    end
 
   # Adds fake test data to the environment to test shibboleth in development.
   def test_data

--- a/lib/mconf/shibboleth.rb
+++ b/lib/mconf/shibboleth.rb
@@ -155,6 +155,12 @@ module Mconf
       end
     end
 
+    def create_notification(user, token)
+      RecentActivity.create(
+        key: 'shibboleth.user.created', owner: token, trackable: user, notified: false
+      )
+    end
+
     private
 
     # Splits a string `value` into several RegExps. Breaks the string at every
@@ -172,5 +178,6 @@ module Mconf
     def create_token(id)
       ShibToken.new(identifier: id)
     end
+
   end
 end

--- a/lib/mconf/shibboleth.rb
+++ b/lib/mconf/shibboleth.rb
@@ -133,9 +133,7 @@ module Mconf
 
       user = User.new params
       user.skip_confirmation!
-      if user.save
-        create_notification(user, shib_token)
-      else
+      if !user.save
         Rails.logger.error "Shibboleth: error while saving the user model"
         Rails.logger.error "Shibboleth: errors: " + user.errors.full_messages.join(", ")
       end
@@ -174,12 +172,5 @@ module Mconf
     def create_token(id)
       ShibToken.new(identifier: id)
     end
-
-    def create_notification(user, token)
-      RecentActivity.create(
-        key: 'shibboleth.user.created', owner: token, trackable: user, notified: false
-      )
-    end
-
   end
 end

--- a/spec/controllers/shibboleth_controller_spec.rb
+++ b/spec/controllers/shibboleth_controller_spec.rb
@@ -43,6 +43,15 @@ describe ShibbolethController do
       before { ShibToken.create!(:identifier => user.email, :user => user) }
       before(:each) { run_route }
       it { should redirect_to(shibboleth_path) }
+      context "creates a RecentActivity" do
+        subject { RecentActivity.where(key: 'shibboleth.user.created').last }
+        it("should exist") { subject.should_not be_nil }
+        it("should point to the right trackable") { subject.trackable.should eq(User.last) }
+        it("should be unnotified") { subject.notified.should be(false) }
+       # see #1737
+        it("should be owned by a ShibToken") { subject.owner.class.should be(ShibToken) }
+        it("should be owned by the correct ShibToken") { subject.owner_id.should eql(ShibToken.last.id) } # calls the last ShibToken because now the RecentActivity is created after the token is save in the database
+      end
     end
 
     context "if there's no valid token yet" do

--- a/spec/lib/mconf/shibboleth_spec.rb
+++ b/spec/lib/mconf/shibboleth_spec.rb
@@ -541,17 +541,6 @@ describe Mconf::Shibboleth do
       it("should be confirmed") { @subject.confirmed_at.should_not be_nil }
       it("should not be disabled") { @subject.disabled.should be_falsey }
       it("should not be a superuser") { @subject.superuser.should be_falsey }
-
-      context "creates a RecentActivity" do
-        subject { RecentActivity.where(key: 'shibboleth.user.created').last }
-        it("should exist") { subject.should_not be_nil }
-        it("should point to the right trackable") { subject.trackable.should eq(User.last) }
-        it("should be unnotified") { subject.notified.should be(false) }
-
-        # see #1737
-        skip("should be owned by a ShibToken") { subject.owner.class.should be(ShibToken) }
-        skip("should be owned by the correct ShibToken") { subject.owner_id.should eql(token.id) }
-      end
     end
 
     context "parameterizes the login" do
@@ -571,7 +560,7 @@ describe Mconf::Shibboleth do
       subject {
         expect {
           @user = shibboleth.create_user(token)
-        }.not_to change{ RecentActivity.count + User.count }
+        }.not_to change{ User.count }
         @user
       }
       it("should return the user") { subject.should_not be_nil }
@@ -580,7 +569,6 @@ describe Mconf::Shibboleth do
       it("expects errors on :email") { subject.errors.should have_key(:email) }
       it("expects errors on :username") { subject.errors.should have_key(:username) }
       it("expects errors on :_full_name") { subject.errors.should have_key(:_full_name) }
-      it("should not create an activity") { RecentActivity.where(key: 'shibboleth.user.created').should be_empty }
     end
   end
 

--- a/spec/workers/user_notifications_worker_spec.rb
+++ b/spec/workers/user_notifications_worker_spec.rb
@@ -162,7 +162,7 @@ describe UserNotificationsWorker do
         it { expect(UserNeedsApprovalSenderWorker).to have_queue_size_of(0) }
         context "should generate the activities anyway" do
           it { RecentActivity.where(trackable: user1, key: 'user.created').first.should_not be_nil }
-          it { RecentActivity.where(trackable: user2, key: 'user.created').first.should_not be_nil }
+          it { RecentActivity.where(trackable_id: user2, key: 'user.created').first.should_not be_nil }
         end
       end
 
@@ -208,6 +208,7 @@ describe UserNotificationsWorker do
           @user = shibboleth.create_user(token)
           token.user = @user
           token.save!
+          shibboleth.create_notification(token.user, token)
         }.to change{ User.count }.by(1)
       }
 

--- a/spec/workers/user_notifications_worker_spec.rb
+++ b/spec/workers/user_notifications_worker_spec.rb
@@ -181,8 +181,8 @@ describe UserNotificationsWorker do
         it { activity.trackable.should eql(@user) }
         it { activity.notified.should be(false) }
 
-        # see #1737
-        skip { activity.owner.should eql(token) }
+        # Now working, see #1737
+        it { activity.owner.should eql(token) }
       end
 
       context "#perform sends the right mails and updates the activity" do
@@ -208,7 +208,7 @@ describe UserNotificationsWorker do
           @user = shibboleth.create_user(token)
           token.user = @user
           token.save!
-          shibboleth.create_notification(token.user, token)
+          shibboleth.create_notification(token.user, token) # TODO: Let's refactor in the future. see #1128
         }.to change{ User.count }.by(1)
       }
 


### PR DESCRIPTION
…ter both and user are stored in the database

- The solution was puts the call to the method "create_notfication(user,shibtoken)" after the token.save! at shibboleth_controller.rb (from /lib/mconf/shibboleth.rb)
- The create_notification method was moved from /lib/mconf/shibboleth.rb to the /controller/shibboleth_controller.rb
	--> (It seems it was created only in "create_user(token)", because a call from controller (shib.create_notification(user,token)) didn't work -error: "undefined "shib"" )
- The tests for the RecentActivity creation was moved from /spec/lib/mconf/shibboleth_spec.rb to /spec/controller/shibboleth_controller_spec.rb
	--> The tests were added to the context "a caller of #associate_with_new_aacount", line 41
	--> In the last test "shoul be owned by the correct ShibToken", the subject.owner_id is now compared to the ShibToken.last.id, because now the activity is created after the ShibToken was save in the database

refs #1737