### PR TITLE
Bug1719

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -266,9 +266,12 @@ class ApplicationController < ActionController::Base
                       "/secure", "/secure/info", "/secure/associate",
                       "/pending" ]
 
+    # Some xhr request need to be stored
+    xhr_paths = ["/manage/users", "/manage/spaces"]
+
     # This will filter xhr requests that are not for html pages. Requests for html pages
     # via ajax can change the url and we might want to store them.
-    valid_format = request.format == "text/html" || request.content_type == "text/html"
+    valid_format = (request.format == "text/html" || request.content_type == "text/html") && ( !request.xhr? || xhr_paths.include?(path) )
 
     !ignored_paths.include?(path) && valid_format
   end

--- a/app/controllers/shibboleth_controller.rb
+++ b/app/controllers/shibboleth_controller.rb
@@ -158,6 +158,7 @@ class ShibbolethController < ApplicationController
         logger.info "Shibboleth: created a new account: #{user.inspect}"
         token.data = shib.get_data
         token.save! # TODO: what if it fails
+        create_notification(token.user, token)
         flash[:success] = t('shibboleth.create_association.account_created', url: new_user_password_path).html_safe
       else
         logger.info "Shibboleth: error saving the new user created: #{user.errors.full_messages}"
@@ -220,6 +221,12 @@ class ShibbolethController < ApplicationController
   def get_always_new_account
     return current_site.shib_always_new_account
   end
+
+   def create_notification(user, token)
+      RecentActivity.create(
+        key: 'shibboleth.user.created', owner: token, trackable: user, notified: false
+      )
+    end
 
   # Adds fake test data to the environment to test shibboleth in development.
   def test_data

--- a/lib/mconf/shibboleth.rb
+++ b/lib/mconf/shibboleth.rb
@@ -133,9 +133,7 @@ module Mconf
 
       user = User.new params
       user.skip_confirmation!
-      if user.save
-        create_notification(user, shib_token)
-      else
+      if !user.save
         Rails.logger.error "Shibboleth: error while saving the user model"
         Rails.logger.error "Shibboleth: errors: " + user.errors.full_messages.join(", ")
       end
@@ -174,12 +172,5 @@ module Mconf
     def create_token(id)
       ShibToken.new(identifier: id)
     end
-
-    def create_notification(user, token)
-      RecentActivity.create(
-        key: 'shibboleth.user.created', owner: token, trackable: user, notified: false
-      )
-    end
-
   end
 end

--- a/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
+++ b/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
@@ -39,6 +39,22 @@ describe CustomBigbluebuttonRoomsController do
     it "loads and authorizes the room into @room"
   end
 
+  describe "#invitation" do
+     # see bug #1719
+    context "doesnt store location for redirect from xhr" do
+      let(:user) { FactoryGirl.create(:user) }
+      before {
+        sign_in user
+        controller.session[:user_return_to] = "/home"
+        controller.session[:previous_user_return_to] = "/manage/users"
+        request.env['CONTENT_TYPE'] = "text/html"
+        xhr :get, :invitation, id: user.bigbluebutton_room.to_param
+      }
+      it { controller.session[:user_return_to].should eq( "/home") }
+      it { controller.session[:previous_user_return_to].should eq("/manage/users") }
+    end
+  end
+
   describe "#invite" do
     context "template and layout" do
       let(:room) { FactoryGirl.create(:bigbluebutton_room, :owner => FactoryGirl.create(:user)) }

--- a/spec/controllers/manage_controller_spec.rb
+++ b/spec/controllers/manage_controller_spec.rb
@@ -13,6 +13,20 @@ describe ManageController do
 
     it "should require authentication"
 
+    # see bug #1719
+    context "stores location for redirect from xhr" do
+      let(:superuser) { FactoryGirl.create(:superuser) }
+      let(:user) { FactoryGirl.create(:user) }
+      before {
+        sign_in superuser
+        controller.session[:user_return_to] = "/home"
+        request.env['CONTENT_TYPE'] = "text/html"
+        xhr :get, :users
+      }
+      it { controller.session[:user_return_to].should eq("/manage/users") }
+      it { controller.session[:previous_user_return_to].should eq("/home") }
+    end
+
     context "authorizes" do
       let(:user) { FactoryGirl.create(:superuser) }
       before(:each) { sign_in(user) }

--- a/spec/controllers/shibboleth_controller_spec.rb
+++ b/spec/controllers/shibboleth_controller_spec.rb
@@ -43,6 +43,15 @@ describe ShibbolethController do
       before { ShibToken.create!(:identifier => user.email, :user => user) }
       before(:each) { run_route }
       it { should redirect_to(shibboleth_path) }
+      context "creates a RecentActivity" do
+        subject { RecentActivity.where(key: 'shibboleth.user.created').last }
+        it("should exist") { subject.should_not be_nil }
+        it("should point to the right trackable") { subject.trackable.should eq(User.last) }
+        it("should be unnotified") { subject.notified.should be(false) }
+       # see #1737
+        it("should be owned by a ShibToken") { subject.owner.class.should be(ShibToken) }
+        it("should be owned by the correct ShibToken") { subject.owner_id.should eql(ShibToken.last.id) } # calls the last ShibToken because now the RecentActivity is created after the token is save in the database
+      end
     end
 
     context "if there's no valid token yet" do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -857,6 +857,20 @@ describe UsersController do
   end
 
   describe "#new" do
+    # see bug #1719
+    context "doesnt store location for redirect from xhr" do
+      let(:superuser) { FactoryGirl.create(:superuser) }
+      before {
+        sign_in superuser
+        controller.session[:user_return_to] = "/home"
+        controller.session[:previous_user_return_to] = "/manage/users"
+        request.env['CONTENT_TYPE'] = "text/html"
+        xhr :get, :new
+      }
+      it { controller.session[:user_return_to].should eq( "/home") }
+      it { controller.session[:previous_user_return_to].should eq("/manage/users") }
+    end
+
     context "logged as a superuser" do
       let(:superuser) { FactoryGirl.create(:superuser) }
       before(:each) { sign_in(superuser) }

--- a/spec/features/users/edit_user_account_spec.rb
+++ b/spec/features/users/edit_user_account_spec.rb
@@ -53,10 +53,28 @@ feature 'Editing a user account' do
     expect(current_path_with_query).to eq(path)
   end
 
+  # # bug1719 - Waiting for javascript tests
+  # scenario "a user edit his account after acces a modal in his home page " do
+  #   sign_in_with user.username, user.password
+  #   visit my_home_path
+  #   # try to invite users to his meeting
+  #   find("a[href='#{ invitation_bigbluebutton_room_path(user) }']").click
+  #   # closes/cancel the model
+  #   find("a[data-dismiss='modal']").click
+  #   # click on account
+  #   find("a[href='#{ edit_user_path(user) }']").click
+  #   # click on cancel
+  #   find("//a[text()='#{ I18n.t('simple_form.buttons.cancel') }']").click
+
+  #    expect(current_path).to eq(my_home_path)
+  #   show_page
+  # end
+
   scenario "a user accessing his own page should see current password field" do
     sign_in_with user.username, user.password
 
     visit edit_user_path(user)
+    show_page
 
     expect(page).to have_field("user_email", disabled: true, with: user.email)
     expect(page).to have_field("user_username", disabled: true, with: user.username)

--- a/spec/lib/mconf/shibboleth_spec.rb
+++ b/spec/lib/mconf/shibboleth_spec.rb
@@ -541,17 +541,6 @@ describe Mconf::Shibboleth do
       it("should be confirmed") { @subject.confirmed_at.should_not be_nil }
       it("should not be disabled") { @subject.disabled.should be_falsey }
       it("should not be a superuser") { @subject.superuser.should be_falsey }
-
-      context "creates a RecentActivity" do
-        subject { RecentActivity.where(key: 'shibboleth.user.created').last }
-        it("should exist") { subject.should_not be_nil }
-        it("should point to the right trackable") { subject.trackable.should eq(User.last) }
-        it("should be unnotified") { subject.notified.should be(false) }
-
-        # see #1737
-        skip("should be owned by a ShibToken") { subject.owner.class.should be(ShibToken) }
-        skip("should be owned by the correct ShibToken") { subject.owner_id.should eql(token.id) }
-      end
     end
 
     context "parameterizes the login" do
@@ -571,7 +560,7 @@ describe Mconf::Shibboleth do
       subject {
         expect {
           @user = shibboleth.create_user(token)
-        }.not_to change{ RecentActivity.count + User.count }
+        }.not_to change{ User.count }
         @user
       }
       it("should return the user") { subject.should_not be_nil }
@@ -580,7 +569,6 @@ describe Mconf::Shibboleth do
       it("expects errors on :email") { subject.errors.should have_key(:email) }
       it("expects errors on :username") { subject.errors.should have_key(:username) }
       it("expects errors on :_full_name") { subject.errors.should have_key(:_full_name) }
-      it("should not create an activity") { RecentActivity.where(key: 'shibboleth.user.created').should be_empty }
     end
   end
 


### PR DESCRIPTION
Any xhr request that is not from /manage/users or /manage/spaces, is a ignored path.

That correct the bug  when you access a modal, via xhr, close it, and then access any page that will redirect back.

    refs #1719
