### PR TITLE
Bugs1719 1721

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -264,7 +264,7 @@ class ApplicationController < ActionController::Base
                       "/users/password", "/users/password/new",
                       "/users/confirmation/new", "/users/confirmation",
                       "/secure", "/secure/info", "/secure/associate",
-                      "/pending", "^/bigbluebutton/rooms/.*/join$", "^/bigbluebutton/rooms/.*/end$"]
+                      "/pending", "/bigbluebutton/rooms/.*/join", "/bigbluebutton/rooms/.*/end"]
 
     # Some xhr request need to be stored
     xhr_paths = ["/manage/users", "/manage/spaces"]
@@ -273,7 +273,7 @@ class ApplicationController < ActionController::Base
     # via ajax can change the url and we might want to store them.
     valid_format = (request.format == "text/html" || request.content_type == "text/html") && ( !request.xhr? || xhr_paths.include?(path) )
 
-    ignored_paths.select{ |ignored| path.match(ignored) }.empty? && valid_format
+    ignored_paths.select{ |ignored| path.match("^"+ignored+"$") }.empty? && valid_format
   end
 
   # Store last url for post-login redirect to whatever the user last visited.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -266,9 +266,12 @@ class ApplicationController < ActionController::Base
                       "/secure", "/secure/info", "/secure/associate",
                       "/pending" ]
 
+    # Some xhr request need to be stored
+    xhr_paths = ["/manage/users", "/manage/spaces"]
+
     # This will filter xhr requests that are not for html pages. Requests for html pages
     # via ajax can change the url and we might want to store them.
-    valid_format = request.format == "text/html" || request.content_type == "text/html"
+    valid_format = (request.format == "text/html" || request.content_type == "text/html") && ( !request.xhr? || xhr_paths.include?(path) )
 
     !ignored_paths.include?(path) && valid_format
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -264,7 +264,7 @@ class ApplicationController < ActionController::Base
                       "/users/password", "/users/password/new",
                       "/users/confirmation/new", "/users/confirmation",
                       "/secure", "/secure/info", "/secure/associate",
-                      "/pending" ]
+                      "/pending", "^/bigbluebutton/rooms/.*/join$", "^/bigbluebutton/rooms/.*/end$"]
 
     # Some xhr request need to be stored
     xhr_paths = ["/manage/users", "/manage/spaces"]
@@ -273,7 +273,7 @@ class ApplicationController < ActionController::Base
     # via ajax can change the url and we might want to store them.
     valid_format = (request.format == "text/html" || request.content_type == "text/html") && ( !request.xhr? || xhr_paths.include?(path) )
 
-    !ignored_paths.include?(path) && valid_format
+    ignored_paths.select{ |ignored| path.match(ignored) }.empty? && valid_format
   end
 
   # Store last url for post-login redirect to whatever the user last visited.

--- a/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
+++ b/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
@@ -495,6 +495,41 @@ describe CustomBigbluebuttonRoomsController do
 
   describe "#join" do
 
+    # see bug1721
+    context "doesnt store location for redirect for /bigbluebutton/rooms/:user/join " do
+      let(:user) { FactoryGirl.create(:user) }
+      let(:room) { user.bigbluebutton_room }
+      before {
+        login_as(user)
+        BigbluebuttonRoom.stub(:find_by!) { room }
+
+        controller.session[:user_return_to] = "/home"
+        controller.session[:previous_user_return_to] = "/manage/users"
+        request.env['CONTENT_TYPE'] = "text/html"
+      }
+
+      context "when a meeting is running" do
+        before{
+          room.stub(:is_running?) { true }
+          room.should_receive(:fetch_is_running?).at_least(:once) { true }
+          room.should_receive(:fetch_meeting_info)
+          get :join, id: room.to_param
+        }
+        it { controller.session[:user_return_to].should eq( "/home") }
+        it { controller.session[:previous_user_return_to].should eq("/manage/users") }
+      end
+      context "when no meeting is running" do
+        before {
+          room.stub(:is_running?) { false }
+          room.should_receive(:fetch_is_running?).at_least(:once) { false }
+          room.should_not_receive(:fetch_meeting_info)
+          get :join, id: room.to_param
+        }
+        it { controller.session[:user_return_to].should eq( "/home") }
+        it { controller.session[:previous_user_return_to].should eq("/manage/users") }
+      end
+    end
+
     for method in [:get, :post]
       context "via #{method}" do
 
@@ -790,6 +825,41 @@ describe CustomBigbluebuttonRoomsController do
     before {
       request.env["HTTP_REFERER"] = "/any"
     }
+
+    # see bug1721
+    context "doesnt store location for redirect for /bigbluebutton/rooms/:user/end " do
+      let(:user) { FactoryGirl.create(:user) }
+      let(:room) { user.bigbluebutton_room }
+      before {
+        login_as(user)
+        BigbluebuttonRoom.stub(:find_by!) { room }
+
+        controller.session[:user_return_to] = "/home"
+        controller.session[:previous_user_return_to] = "/manage/users"
+        request.env['CONTENT_TYPE'] = "text/html"
+      }
+
+      context "when a meeting is running" do
+        before{
+          room.stub(:is_running?) { true }
+          room.should_receive(:fetch_is_running?).at_least(:once) { true }
+          room.should_receive(:fetch_meeting_info)
+          get :end, id: room.to_param
+        }
+        it { controller.session[:user_return_to].should eq( "/home") }
+        it { controller.session[:previous_user_return_to].should eq("/manage/users") }
+      end
+      context "when no meeting is running" do
+        before {
+          room.stub(:is_running?) { false }
+          room.should_receive(:fetch_is_running?).at_least(:once) { false }
+          room.should_not_receive(:fetch_meeting_info)
+          get :end, id: room.to_param
+        }
+        it { controller.session[:user_return_to].should eq( "/home") }
+        it { controller.session[:previous_user_return_to].should eq("/manage/users") }
+      end
+    end
 
     context "fetches information about the room when calling #end" do
       let(:user) { FactoryGirl.create(:user) }

--- a/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
+++ b/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
@@ -39,6 +39,22 @@ describe CustomBigbluebuttonRoomsController do
     it "loads and authorizes the room into @room"
   end
 
+  describe "#invitation" do
+     # see bug #1719
+    context "doesnt store location for redirect from xhr" do
+      let(:user) { FactoryGirl.create(:user) }
+      before {
+        sign_in user
+        controller.session[:user_return_to] = "/home"
+        controller.session[:previous_user_return_to] = "/manage/users"
+        request.env['CONTENT_TYPE'] = "text/html"
+        xhr :get, :invitation, id: user.bigbluebutton_room.to_param
+      }
+      it { controller.session[:user_return_to].should eq( "/home") }
+      it { controller.session[:previous_user_return_to].should eq("/manage/users") }
+    end
+  end
+
   describe "#invite" do
     context "template and layout" do
       let(:room) { FactoryGirl.create(:bigbluebutton_room, :owner => FactoryGirl.create(:user)) }

--- a/spec/controllers/manage_controller_spec.rb
+++ b/spec/controllers/manage_controller_spec.rb
@@ -13,6 +13,20 @@ describe ManageController do
 
     it "should require authentication"
 
+    # see bug #1719
+    context "stores location for redirect from xhr" do
+      let(:superuser) { FactoryGirl.create(:superuser) }
+      let(:user) { FactoryGirl.create(:user) }
+      before {
+        sign_in superuser
+        controller.session[:user_return_to] = "/home"
+        request.env['CONTENT_TYPE'] = "text/html"
+        xhr :get, :users
+      }
+      it { controller.session[:user_return_to].should eq("/manage/users") }
+      it { controller.session[:previous_user_return_to].should eq("/home") }
+    end
+
     context "authorizes" do
       let(:user) { FactoryGirl.create(:superuser) }
       before(:each) { sign_in(user) }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -857,6 +857,20 @@ describe UsersController do
   end
 
   describe "#new" do
+    # see bug #1719
+    context "doesnt store location for redirect from xhr" do
+      let(:superuser) { FactoryGirl.create(:superuser) }
+      before {
+        sign_in superuser
+        controller.session[:user_return_to] = "/home"
+        controller.session[:previous_user_return_to] = "/manage/users"
+        request.env['CONTENT_TYPE'] = "text/html"
+        xhr :get, :new
+      }
+      it { controller.session[:user_return_to].should eq( "/home") }
+      it { controller.session[:previous_user_return_to].should eq("/manage/users") }
+    end
+
     context "logged as a superuser" do
       let(:superuser) { FactoryGirl.create(:superuser) }
       before(:each) { sign_in(superuser) }

--- a/spec/features/users/edit_user_account_spec.rb
+++ b/spec/features/users/edit_user_account_spec.rb
@@ -53,10 +53,28 @@ feature 'Editing a user account' do
     expect(current_path_with_query).to eq(path)
   end
 
+  # # bug1719 - Waiting for javascript tests
+  # scenario "a user edit his account after acces a modal in his home page " do
+  #   sign_in_with user.username, user.password
+  #   visit my_home_path
+  #   # try to invite users to his meeting
+  #   find("a[href='#{ invitation_bigbluebutton_room_path(user) }']").click
+  #   # closes/cancel the model
+  #   find("a[data-dismiss='modal']").click
+  #   # click on account
+  #   find("a[href='#{ edit_user_path(user) }']").click
+  #   # click on cancel
+  #   find("//a[text()='#{ I18n.t('simple_form.buttons.cancel') }']").click
+
+  #    expect(current_path).to eq(my_home_path)
+  #   show_page
+  # end
+
   scenario "a user accessing his own page should see current password field" do
     sign_in_with user.username, user.password
 
     visit edit_user_path(user)
+    show_page
 
     expect(page).to have_field("user_email", disabled: true, with: user.email)
     expect(page).to have_field("user_username", disabled: true, with: user.username)

--- a/spec/features/users/edit_user_account_spec.rb
+++ b/spec/features/users/edit_user_account_spec.rb
@@ -74,7 +74,6 @@ feature 'Editing a user account' do
     sign_in_with user.username, user.password
 
     visit edit_user_path(user)
-    show_page
 
     expect(page).to have_field("user_email", disabled: true, with: user.email)
     expect(page).to have_field("user_username", disabled: true, with: user.username)


### PR DESCRIPTION
Any xhr request that is not from /manage/users or /manage/spaces, is a ignored path.

That correct the bug when you access a modal, via xhr, close it, and then access any page that will redirect back.

refs #1719


Both paths /bigbluebutton/rooms/:user/join ans /bigbluebutton/rooms/:user:end can not be redirectable

In application contrroler was added the regex for the both paths and changed the test for ignored paths from "include?" to "match", for each path.

refs #1721
