### PR TITLE
Update the data in shib tokens after every valid sign in

### DIFF
--- a/app/controllers/shibboleth_controller.rb
+++ b/app/controllers/shibboleth_controller.rb
@@ -32,10 +32,10 @@ class ShibbolethController < ApplicationController
       @attrs_informed = @shib.get_data
       render :attribute_error
     else
-      token = @shib.find_token()
+      token = @shib.find_and_update_token
 
       # there's a token with a user associated
-      if !token.nil? && !token.user_with_disabled.nil?
+      if token.present? && !token.user_with_disabled.nil?
         user = token.user_with_disabled
         if user.disabled
           logger.info "Shibolleth: user local account is disabled, can't login"
@@ -157,7 +157,7 @@ class ShibbolethController < ApplicationController
       if user && user.errors.empty?
         logger.info "Shibboleth: created a new account: #{user.inspect}"
         token.data = shib.get_data
-        token.save! # TODO: what if it fails
+        token.save!
         shib.create_notification(token.user, token)
         flash[:success] = t('shibboleth.create_association.account_created', url: new_user_password_path).html_safe
       else
@@ -204,7 +204,7 @@ class ShibbolethController < ApplicationController
       token = shib.find_or_create_token()
       token.user = user
       token.data = shib.get_data()
-      token.save! # TODO: what if it fails
+      token.save!
 
       # If the user comes from shibboleth and is not confirmed we can trust him
       if !user.confirmed?

--- a/lib/mconf/shibboleth.rb
+++ b/lib/mconf/shibboleth.rb
@@ -105,7 +105,20 @@ module Mconf
 
     # Finds the ShibToken associated with the user whose information is stored in the session.
     def find_token
-      ShibToken.find_by_identifier(get_identifier())
+      ShibToken.find_by_identifier(get_identifier)
+    end
+
+    # Finds the ShibToken and updates it with the information in the session, unless
+    # it's empty. Returns the token.
+    # Doesn't raise an exception if it fails to save the token, will return the
+    # errors in the model.
+    def find_and_update_token
+      token = find_token
+      if token.present? && !get_data.blank?
+        token.data = get_data
+        token.save
+      end
+      token
     end
 
     # Searches for a ShibToken using data in the session and returns it. Creates a new

--- a/spec/controllers/shibboleth_controller_spec.rb
+++ b/spec/controllers/shibboleth_controller_spec.rb
@@ -305,6 +305,21 @@ describe ShibbolethController do
         it { should set_the_flash.to(I18n.t('shibboleth.login.local_account_disabled'))}
         it { should redirect_to(root_path) }
       end
+
+      context "updates the data in the token with the data in the session" do
+        let(:old_data) { { "Shib-cn": "My Name", "Shib-id": 12345, "AnotherParam": "no value" } }
+        let(:new_data) {
+          { "Shib-inetOrgPerson-cn" => user.full_name,
+            "Shib-inetOrgPerson-mail" => user.email,
+            "Shib-eduPerson-eduPersonPrincipalName" => user.email }
+        }
+        let!(:token) { ShibToken.create!(identifier: user.email, user: user, data: old_data) }
+        before {
+          setup_shib(user.full_name, user.email, user.email)
+          get :login
+        }
+        it { token.reload.data.should eql(new_data) }
+      end
     end
   end
 

--- a/spec/lib/mconf/shibboleth_spec.rb
+++ b/spec/lib/mconf/shibboleth_spec.rb
@@ -489,6 +489,79 @@ describe Mconf::Shibboleth do
     end
   end
 
+  describe "#find_and_update_token" do
+    let(:shibboleth) { Mconf::Shibboleth.new({}) }
+    let(:user) { FactoryGirl.create(:user) }
+
+    context "returns the token using the information in the session" do
+      before {
+        ShibToken.create!(identifier: 'any@email.com', user: user)
+        shibboleth.should_receive(:get_identifier).and_return('any@email.com')
+      }
+      subject { shibboleth.find_and_update_token }
+      it { subject.identifier.should eq('any@email.com') }
+      it { subject.user.should eq(user) }
+    end
+
+    context "returns nil of there's no token" do
+      before {
+        shibboleth.should_receive(:get_identifier).and_return('any@email.com')
+      }
+      subject { shibboleth.find_and_update_token }
+      it { subject.should be_nil }
+    end
+
+    context "updates the token with the info in the session" do
+      let(:old_data) { { "Shib-cn": "My Name", "Shib-id": 12345, "AnotherParam": "no value" } }
+      let(:new_data) { { "Shib-cn": "New Name", "AnotherParam": 12345 } }
+      let(:shibboleth) { Mconf::Shibboleth.new({ shib_data: new_data }) }
+      before {
+        ShibToken.create!(identifier: 'any@email.com', user: user, data: old_data)
+        shibboleth.should_receive(:get_identifier).and_return('any@email.com')
+      }
+      subject {
+        token = shibboleth.find_and_update_token
+        token.reload
+        token
+      }
+      it { subject.data.should eq(new_data) }
+    end
+
+    context "doesn't save if there's no data in the session" do
+      let(:old_data) { { "Shib-cn": "My Name", "Shib-id": 12345, "AnotherParam": "no value" } }
+      let(:new_data) { nil }
+      let(:shibboleth) { Mconf::Shibboleth.new({ shib_data: new_data }) }
+      before {
+        ShibToken.create!(identifier: 'any@email.com', user: user, data: old_data)
+        shibboleth.should_receive(:get_identifier).and_return('any@email.com')
+      }
+      subject {
+        token = shibboleth.find_and_update_token
+        token.reload
+        token
+      }
+      it { subject.data.should eq(old_data) }
+    end
+
+    context "doesn't save if the data in the session is empty" do
+      let(:old_data) { { "Shib-cn": "My Name", "Shib-id": 12345, "AnotherParam": "no value" } }
+      let(:new_data) { {} }
+      let(:shibboleth) { Mconf::Shibboleth.new({ shib_data: new_data }) }
+      before {
+        ShibToken.create!(identifier: 'any@email.com', user: user, data: old_data)
+        shibboleth.should_receive(:get_identifier).and_return('any@email.com')
+      }
+      subject {
+        token = shibboleth.find_and_update_token
+        token.reload
+        token
+      }
+      it { subject.data.should eq(old_data) }
+    end
+
+    it "returns the errors in the token if it failed to update"
+  end
+
   describe "#find_or_create_token" do
     let(:shibboleth) { Mconf::Shibboleth.new({}) }
     let(:user) { FactoryGirl.create(:user) }


### PR DESCRIPTION
Save the data returned by the federation into `ShibToken#data` after every successful sign in. Won't save if it is blank or empty.
So now checking the data in the session or checking the data in `ShibToken#data` should be the same when a user is signed in via Shibboleth.

refs #1778