### PR TITLE
The reference to the user that approved the space is now stored.

### DIFF
--- a/lib/mconf/approval_module.rb
+++ b/lib/mconf/approval_module.rb
@@ -11,7 +11,7 @@ module Mconf
 
     # Starts the process of sending a notification to the model that was approved.
     def create_approval_notification(approved_by)
-      create_activity 'approved', owner: approved_by
+      create_activity 'approved', owner: approved_by, recipient: approved_by, parameters: {:username => approved_by.name }
     end
 
     def approve!

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -751,7 +751,6 @@ describe User do
       it("sets #trackable") { subject.trackable.should eq(user) }
       it("sets #owner") { subject.owner.should eq(approver) }
       it("sets #key") { subject.key.should eq('user.approved') }
-      it("doesn't set #recipient") { subject.recipient.should be_nil }
     end
   end
 


### PR DESCRIPTION
When create an activity, for the key 'approved', as other from Space, it was not storing the recipient and parameters: {:username => ...}, that is used as the reference to the user that approved the Space.

refs #1773