### PR TITLE
Page events/index is not anymore avaliable in unapproved spaces

### DIFF
--- a/app/controllers/space_events_controller.rb
+++ b/app/controllers/space_events_controller.rb
@@ -16,15 +16,19 @@ class SpaceEventsController < ApplicationController
     end
   end
 
-  load_and_authorize_resource :space, :find_by => :permalink
+  load_and_authorize_resource :space, :find_by => :permalink, :parent => true
+  load_and_authorize_resource :event, :through => :space, :class => MwebEvents::Event, :parent => false
   # TODO: #1115, review authorization
-  load_and_authorize_resource :find_by => :permalink, :class => MwebEvents::Event
+  #load_and_authorize_resource :find_by => :permalink, :class => MwebEvents::Event
+
 
   # need it to show info in the sidebar
   before_filter :webconf_room!
 
   # TODO: everything is being filtered by software, this can all be done with db queries
   def index
+    authorize! :index_event, @space
+
     all_events = @space.events(:order => "end_on DESC")
 
     # events happening now

--- a/app/controllers/space_events_controller.rb
+++ b/app/controllers/space_events_controller.rb
@@ -18,14 +18,10 @@ class SpaceEventsController < ApplicationController
 
   load_and_authorize_resource :space, :find_by => :permalink, :parent => true
   load_and_authorize_resource :event, :through => :space, :class => MwebEvents::Event, :parent => false
-  # TODO: #1115, review authorization
-  #load_and_authorize_resource :find_by => :permalink, :class => MwebEvents::Event
-
 
   # need it to show info in the sidebar
   before_filter :webconf_room!
 
-  # TODO: everything is being filtered by software, this can all be done with db queries
   def index
     authorize! :index_event, @space
 
@@ -46,8 +42,7 @@ class SpaceEventsController < ApplicationController
     elsif params[:show] == 'happening_now'
       @current_events = @current_events.paginate(:page => params[:page], :per_page => 5)
 
-    # the 'default' index
-    else
+    else # 'all'
       @last_past_events = all_events.past.first(3)
       @first_upcoming_events = all_events.upcoming.first(3)
     end

--- a/app/models/abilities/base_ability.rb
+++ b/app/models/abilities/base_ability.rb
@@ -78,7 +78,7 @@ module Abilities
 
       cannot [:webconference, :recordings, :manage_join_requests,
               :invite, :user_permissions, :manage_news, :show_news,
-              :webconference_options, :edit_recording], Space, approved: false
+              :webconference_options, :edit_recording, :index_event], Space, approved: false
 
       cannot :manage, Post, space: { approved: false }
       cannot :manage, Attachment, space: { approved: false }

--- a/app/models/abilities/base_ability.rb
+++ b/app/models/abilities/base_ability.rb
@@ -88,8 +88,10 @@ module Abilities
         !jr.group.approved?
       end
 
-      # Obs: index is restricted now using :inex_event abilit, since the use of :index
-      # below would block the index always
+
+      # TODO: should restrict :index too, but can't since it doesn't evaluate the
+      # block and would restrict it always, not only for unapproved spaces
+      # :index of events inside a space is restricted using :index_event
       cannot [:show, :create, :new, :invite], MwebEvents::Event do |event|
         event.owner_type == 'Space' && !event.owner.try(:approved?) # use try because of disabled spaces
       end

--- a/app/models/abilities/base_ability.rb
+++ b/app/models/abilities/base_ability.rb
@@ -88,8 +88,8 @@ module Abilities
         !jr.group.approved?
       end
 
-      # TODO: should restrict :index too, but can't since it doesn't evaluate the
-      # block and would restrict it always, not only for unapproved spaces
+      # Obs: index is restricted now using :inex_event abilit, since the use of :index
+      # below would block the index always
       cannot [:show, :create, :new, :invite], MwebEvents::Event do |event|
         event.owner_type == 'Space' && !event.owner.try(:approved?) # use try because of disabled spaces
       end

--- a/app/models/abilities/member_ability.rb
+++ b/app/models/abilities/member_ability.rb
@@ -59,8 +59,8 @@ module Abilities
       can [:create, :new], Space unless Site.current.forbid_user_space_creation?
 
       can [:index], Space
-      can [:show, :webconference, :recordings, :show_news], Space, public: true
-      can [:show, :webconference, :recordings, :show_news], Space do |space|
+      can [:show, :webconference, :recordings, :show_news, :index_event], Space, public: true
+      can [:show, :webconference, :recordings, :show_news, :index_event], Space do |space|
         space.users.include?(user)
       end
       can [:leave], Space do |space|

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -114,10 +114,6 @@ class Space < ActiveRecord::Base
   # By default spaces marked as disabled will not show in queries
   default_scope -> { where(:disabled => false) }
 
-  # #1795
-  scope :approved, -> { with_disabled.where(approved: true) }
-  scope :unapproved, -> { with_disabled.where(approved: false) }
-
   # This scope can be used as a shorthand for spaces marked as public
   scope :public_spaces, -> { where(:public => true) }
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -114,6 +114,10 @@ class Space < ActiveRecord::Base
   # By default spaces marked as disabled will not show in queries
   default_scope -> { where(:disabled => false) }
 
+  # #1795
+  scope :approved, -> { with_disabled.where(approved: true) }
+  scope :unapproved, -> { with_disabled.where(approved: false) }
+
   # This scope can be used as a shorthand for spaces marked as public
   scope :public_spaces, -> { where(:public => true) }
 

--- a/app/views/spaces/_menu.html.haml
+++ b/app/views/spaces/_menu.html.haml
@@ -15,7 +15,7 @@
             = link_to t('.posts'), space_posts_path(@space)
 
         -# Can't use can?(:index) here because the ability is defined with a block
-        - if mod_enabled?("events") && can?(:show, MwebEvents::Event.new(owner: @space))
+        - if mod_enabled?("events") && can?(:index_event, @space) #:show, MwebEvents::Event.new(owner: @space))
           %li{ spaces_menu_select_if(:events) }
             = link_to t('.events'), space_events_path(@space)
 

--- a/app/views/spaces/_menu.html.haml
+++ b/app/views/spaces/_menu.html.haml
@@ -15,7 +15,7 @@
             = link_to t('.posts'), space_posts_path(@space)
 
         -# Can't use can?(:index) here because the ability is defined with a block
-        - if mod_enabled?("events") && can?(:index_event, @space) #:show, MwebEvents::Event.new(owner: @space))
+        - if mod_enabled?("events") && can?(:index_event, @space) 
           %li{ spaces_menu_select_if(:events) }
             = link_to t('.events'), space_events_path(@space)
 

--- a/app/views/spaces/_menu.html.haml
+++ b/app/views/spaces/_menu.html.haml
@@ -14,8 +14,7 @@
           %li{ spaces_menu_select_if(:posts) }
             = link_to t('.posts'), space_posts_path(@space)
 
-        -# Can't use can?(:index) here because the ability is defined with a block
-        - if mod_enabled?("events") && can?(:index_event, @space) 
+        - if mod_enabled?("events") && can?(:index_event, @space)
           %li{ spaces_menu_select_if(:events) }
             = link_to t('.events'), space_events_path(@space)
 

--- a/app/views/spaces/_sidebar.html.haml
+++ b/app/views/spaces/_sidebar.html.haml
@@ -22,7 +22,7 @@
         .content-block-footer
           = link_to t('view_more'), webconference_space_path(@space)
 
-    - if mod_enabled?("events")
+    - if mod_enabled?("events") && can?(:index_event, @space)
       = render_sidebar_content_block('sidebar-upcoming-events') do
         .content-block-header
           %h4=  t('.upcoming_events')

--- a/spec/controllers/space_events_controller_spec.rb
+++ b/spec/controllers/space_events_controller_spec.rb
@@ -43,7 +43,7 @@ describe SpaceEventsController, :events => true do
     it "returns an rss with all the events in the space"
   end
 
-  # TODO: #1115, review
+  # TODO: there are several missing tests here
   describe "abilities", :abilities => true do
     render_views(false)
 

--- a/spec/models/bigbluebutton_room_spec.rb
+++ b/spec/models/bigbluebutton_room_spec.rb
@@ -18,7 +18,7 @@ describe BigbluebuttonRoom do
     describe "#user_created_meeting?" do
       it "false if there's no current meeting running in the room"
       it "false if it was another user that created the current meeting running in the room"
-      it "true if the current meeting runnigitng in the room was created by the user informed"
+      it "true if the current meeting running in the room was created by the user informed"
     end
   end
 

--- a/spec/models/bigbluebutton_room_spec.rb
+++ b/spec/models/bigbluebutton_room_spec.rb
@@ -18,7 +18,7 @@ describe BigbluebuttonRoom do
     describe "#user_created_meeting?" do
       it "false if there's no current meeting running in the room"
       it "false if it was another user that created the current meeting running in the room"
-      it "true if the current meeting running in the room was created by the user informed"
+      it "true if the current meeting runnigitng in the room was created by the user informed"
     end
   end
 
@@ -132,7 +132,10 @@ describe BigbluebuttonRoom do
         end
 
         context "when the owner is disabled" do
-          before { target.owner.disable }
+          before {
+            target.owner.disable
+            user.update_attributes(:can_record => true)
+          }
           it { should_not be_able_to_do_anything_to(target) }
         end
       end
@@ -204,7 +207,10 @@ describe BigbluebuttonRoom do
           end
 
           context "when the owner is disabled" do
-            before { target.owner.disable }
+            before {
+              target.owner.disable
+              user.update_attributes(:can_record => true)
+            }
             it { should_not be_able_to_do_anything_to(target) }
           end
         end
@@ -237,7 +243,10 @@ describe BigbluebuttonRoom do
           end
 
           context "when the owner is disabled" do
-            before { target.owner.disable }
+            before {
+              target.owner.disable
+              user.update_attributes(:can_record => true)
+            }
             it { should_not be_able_to_do_anything_to(target) }
           end
         end
@@ -268,7 +277,10 @@ describe BigbluebuttonRoom do
           end
 
           context "when the owner is disabled" do
-            before { target.owner.disable }
+            before {
+              target.owner.disable
+              user.update_attributes(:can_record => true)
+            }
             it { should_not be_able_to_do_anything_to(target) }
           end
         end
@@ -281,7 +293,10 @@ describe BigbluebuttonRoom do
           it { should_not be_able_to_do_anything_to(target).except(allowed) }
 
           context "when the owner is disabled" do
-            before { target.owner.disable }
+            before {
+              target.owner.disable
+              user.update_attributes(:can_record => true)
+            }
             it { should_not be_able_to_do_anything_to(target) }
           end
         end

--- a/spec/models/space_spec.rb
+++ b/spec/models/space_spec.rb
@@ -953,7 +953,7 @@ describe Space do
   describe "abilities", :abilities => true do
     set_custom_ability_actions([:leave, :enable, :webconference, :select, :disable, :update_logo,
       :user_permissions, :edit_recording, :webconference_options, :recordings,
-      :manage_join_requests, :show_news, :manage_news, :add])
+      :manage_join_requests, :show_news, :manage_news, :add, :index_event])
 
     subject { ability }
     let(:ability) { Abilities.ability_for(user) }
@@ -1041,7 +1041,7 @@ describe Space do
         let(:target) { FactoryGirl.create(:public_space) }
 
         context "he is not a member of" do
-          it { should_not be_able_to_do_anything_to(target).except([:show, :index, :webconference, :recordings, :create, :new, :select, :show_news]) }
+          it { should_not be_able_to_do_anything_to(target).except([:show, :index, :webconference, :recordings, :create, :new, :select, :show_news, :index_event]) }
         end
 
         context "he is a member of" do
@@ -1052,7 +1052,7 @@ describe Space do
                 list = [
                   :show, :index, :webconference, :recordings, :create, :new, :select, :edit,
                   :update, :update_logo, :disable, :user_permissions, :edit_recording,
-                  :webconference_options, :manage_join_requests, :show_news, :manage_news
+                  :webconference_options, :manage_join_requests, :show_news, :manage_news, :index_event
                 ]
                 should_not be_able_to_do_anything_to(target).except(list)
               }
@@ -1064,7 +1064,7 @@ describe Space do
                 list = [
                   :show, :index, :webconference, :recordings, :create, :new, :select, :leave, :edit,
                   :update, :update_logo, :disable, :user_permissions, :edit_recording,
-                  :webconference_options, :manage_join_requests, :show_news, :manage_news
+                  :webconference_options, :manage_join_requests, :show_news, :manage_news, :index_event
                 ]
                 should_not be_able_to_do_anything_to(target).except(list)
               }
@@ -1086,7 +1086,7 @@ describe Space do
             before { target.add_member!(user, "User") }
             it {
               should_not be_able_to_do_anything_to(target)
-                .except([:show, :index, :webconference, :recordings, :create, :new, :select, :leave, :show_news])
+                .except([:show, :index, :webconference, :recordings, :create, :new, :select, :leave, :show_news, :index_event])
             }
 
             context "when the space is not approved" do
@@ -1117,7 +1117,7 @@ describe Space do
                 list = [
                   :show, :index, :webconference, :recordings, :create, :new, :select, :edit,
                   :update, :update_logo, :disable, :user_permissions, :edit_recording,
-                  :webconference_options, :manage_join_requests, :show_news, :manage_news
+                  :webconference_options, :manage_join_requests, :show_news, :manage_news, :index_event
                 ]
                 should_not be_able_to_do_anything_to(target).except(list)
               }
@@ -1129,7 +1129,7 @@ describe Space do
                 list = [
                   :show, :index, :webconference, :recordings, :create, :new, :select, :leave, :edit,
                   :update, :update_logo, :disable, :user_permissions, :edit_recording,
-                  :webconference_options, :manage_join_requests, :show_news, :manage_news
+                  :webconference_options, :manage_join_requests, :show_news, :manage_news, :index_event
                 ]
                 should_not be_able_to_do_anything_to(target).except(list)
               }
@@ -1151,7 +1151,7 @@ describe Space do
             before { target.add_member!(user, "User") }
             it {
               should_not be_able_to_do_anything_to(target)
-                .except([:show, :index, :webconference, :recordings, :create, :new, :select, :leave, :show_news])
+                .except([:show, :index, :webconference, :recordings, :create, :new, :select, :leave, :show_news, :index_event])
             }
 
             context "when the space is not approved" do


### PR DESCRIPTION
To not authorize the access to events/index it was needed create a new tah :index_events and block in the index with authorize!.

refs #1795