### PR TITLE
Added test to not send a mail to admin for join request when the join…

### DIFF
--- a/app/workers/join_request_sender_worker.rb
+++ b/app/workers/join_request_sender_worker.rb
@@ -19,13 +19,13 @@ class JoinRequestSenderWorker < BaseWorker
 
     if space.nil?
       Resque.logger.info "Invalid space in a recent activity item: #{activity.inspect}"
+    elsif !activity.trackable.present?
+      Resque.logger.info "Invalid trackable in a recent activity item: #{activity.inspect}"
     else
       # notify each admin of the space
       space.admins.each do |admin|
-        if JoinRequest.exists?(:id => activity.trackable_id)
-          Resque.logger.info "Sending join request notification to: #{admin.inspect}"
-          SpaceMailer.join_request_email(activity.trackable.id, admin.id).deliver
-        end
+        Resque.logger.info "Sending join request notification to: #{admin.inspect}"
+        SpaceMailer.join_request_email(activity.trackable.id, admin.id).deliver
       end
     end
 

--- a/app/workers/join_request_sender_worker.rb
+++ b/app/workers/join_request_sender_worker.rb
@@ -22,8 +22,10 @@ class JoinRequestSenderWorker < BaseWorker
     else
       # notify each admin of the space
       space.admins.each do |admin|
-        Resque.logger.info "Sending join request notification to: #{admin.inspect}"
-        SpaceMailer.join_request_email(activity.trackable.id, admin.id).deliver
+        if JoinRequest.exists?(:id => activity.trackable_id)
+          Resque.logger.info "Sending join request notification to: #{admin.inspect}"
+          SpaceMailer.join_request_email(activity.trackable.id, admin.id).deliver
+        end
       end
     end
 

--- a/spec/workers/join_request_sender_worker_spec.rb
+++ b/spec/workers/join_request_sender_worker_spec.rb
@@ -96,11 +96,24 @@ describe JoinRequestSenderWorker do
       it { activity.reload.notified.should be(true) }
     end
 
+    context "when there's no join request set in the activity" do
+      let(:admin) { FactoryGirl.create(:user) }
+      before {
+        space.add_member!(admin, "Admin")
+        activity.update_attributes(trackable: nil)
+      }
+      before(:each) { worker.perform(activity.id) }
+
+      it { SpaceMailer.should have_queue_size_of(0) }
+      it { SpaceMailer.should_not have_queued(:join_request_email, activity.trackable_id, admin.id).in(:mailer) }
+      it { activity.reload.notified.should be(true) }
+    end
+
     context "when the join request was removed" do
       let(:admin) { FactoryGirl.create(:user) }
-      before{
+      before {
         space.add_member!(admin, "Admin")
-        activity.update_attributes(trackable_id: -1)
+        activity.update_attributes(trackable_id: -1, trackable_type: 'JoinRequest')
       }
       before(:each) { worker.perform(activity.id) }
 

--- a/spec/workers/join_request_sender_worker_spec.rb
+++ b/spec/workers/join_request_sender_worker_spec.rb
@@ -96,5 +96,17 @@ describe JoinRequestSenderWorker do
       it { activity.reload.notified.should be(true) }
     end
 
+    context "when the join request was removed" do
+      let(:admin) { FactoryGirl.create(:user) }
+      before{
+        space.add_member!(admin, "Admin")
+        activity.update_attributes(trackable_id: -1)
+      }
+      before(:each) { worker.perform(activity.id) }
+
+      it { SpaceMailer.should have_queue_size_of(0) }
+      it { SpaceMailer.should_not have_queued(:join_request_email, activity.trackable_id, admin.id).in(:mailer) }
+      it { activity.reload.notified.should be(true) }
+    end
   end
 end


### PR DESCRIPTION
… request doesn't exist anymore

When the join_request_worker perform, it notify each admin of the space but it didn't test if the join request still exists,
making the error "undefined method 'id' for nil:NillClass" when using "activity.trackable.id" in the method
SpaceMailer.join_request_email.

refs #1730