### PR TITLE
Remove unescaped HTML in user inputs

### DIFF
--- a/app/views/layouts/_spaces_page_title.html.haml
+++ b/app/views/layouts/_spaces_page_title.html.haml
@@ -6,11 +6,11 @@
     - if @space.name.size > 60
       .main-title.small-title
         = link_to space_path(@space) do
-          = sanitize(first_words(@space.name, 60))
+          = first_words(@space.name, 60)
     - else
       .main-title
         = link_to space_path(@space) do
-          = sanitize(@space.name)
+          = @space.name
     - if @space.public
       .resource-visibility.public
         = icon_space_public

--- a/app/views/space_events/_sidebar_events_simple.html.haml
+++ b/app/views/space_events/_sidebar_events_simple.html.haml
@@ -3,6 +3,6 @@
 - else
   - for event in events
     .event-wrapper
-      = link_to sanitize(event.name), mweb_events.event_path(event), :class => "event-title"
+      = link_to event.name, mweb_events.event_path(event), :class => "event-title"
       %span.event-date
         = "#{I18n.l(event.start_on, format: :short)} - #{I18n.l(event.end_on, format: :short)}"

--- a/app/views/spaces/_unified_space.html.haml
+++ b/app/views/spaces/_unified_space.html.haml
@@ -16,7 +16,7 @@
     .thread-content
       .thread-title
         %span
-          = link_to sanitize(space.name), space_path(space)
+          = link_to space.name, space_path(space)
 
         - if extended
           - if is_member
@@ -40,7 +40,7 @@
 
       .thread-text
         - if extended
-          = sanitize(auto_link(space.description))
+          = space.description
         - if show_join_request
           - jr = space.pending_join_request_or_invitation_for(current_user)
           - if jr

--- a/app/views/spaces/index.html.haml
+++ b/app/views/spaces/index.html.haml
@@ -23,15 +23,15 @@
       .content-block-middle{:id => "#{space.permalink}-description", :style => "display:none;"}
         .space-logo-wrapper
           - if has_access
-            = link_logo_image(space, :size => '168x128', :title => sanitize(space.name), :class => "logo logo-space")
+            = link_logo_image(space, :size => '168x128', :title => space.name, :class => "logo logo-space")
           - else
-            = logo_image(space, :size => '168x128', :title => sanitize(space.name), :class => "logo logo-space")
+            = logo_image(space, :size => '168x128', :title => space.name, :class => "logo logo-space")
         - if has_access
           = link_to space_path(space) do
-            %h3.name= sanitize(space.name)
+            %h3.name= space.name
         - else
-          %h3.name= sanitize(space.name)
-        %p.description= sanitize(first_words(space.description, 400))
+          %h3.name= space.name
+        %p.description= first_words(space.description, 400)
         %p.details
           - if space.users.include?(current_user)
             %span.is-member= t('space.index.user_is_member')

--- a/app/views/users/_detailed_user.html.haml
+++ b/app/views/users/_detailed_user.html.haml
@@ -5,20 +5,19 @@
     .logo-in-thread
       = link_logo_image(user, :size => '48', :url => user_path(user), :title => user.name, :class => "logo logo-user-big")
     .thread-title
-      = link_to sanitize(user.full_name), user_path(user), :class => 'user-name'
+      = link_to user.full_name, user_path(user), :class => 'user-name'
     .user-text
       -# the only information that is private here is the email, the others are
       -# in the public profile
       - if can?(:show, user.profile)
         %span.user-mail= mail_to(user.email, user.email)
 
-      - if !user.organization.blank? || !user.location.blank?
-        %span.user-info-prefix= t(".from")
+        - if !user.organization.blank? || !user.location.blank?
+          %span.user-info-prefix= t(".from")
 
-      - unless user.organization.blank?
-        %span.user-organization= sanitize(user.organization)
-        - unless user.location.blank?
-          %span.user-divider= "--"
+        - unless user.organization.blank?
+          %span.user-organization= user.organization
+          - unless user.location.blank?
+            %span.user-divider= "--"
 
-      - unless user.location.blank?
-        %span.user-location= sanitize(user.location)
+          %span.user-location= user.location


### PR DESCRIPTION
Correct places where html tags in user input would be rendered into the page. 

Conflicts:
	app/views/users/_detailed_user.html.haml