### PR TITLE
Invitation to a private space shouldn't send the link to the space.

### DIFF
--- a/app/mailers/views/space_mailer/invitation_email.html.haml
+++ b/app/mailers/views/space_mailer/invitation_email.html.haml
@@ -5,4 +5,7 @@
     %p= t('.message.user_message', sender: @user.full_name).html_safe
     .invite-message= @invitation.comment
 
-  %p= t('.message.link', url: space_join_request_url(@invitation.group, @invitation, host: Site.current.domain), space_url: space_url(@space, host: Site.current.domain)).html_safe
+  %p= t('.message.link', url: space_join_request_url(@invitation.group, @invitation, host: Site.current.domain)).html_safe
+
+  - if @space.public
+    %p= t('.message.space_info', space_url: space_url(@space, host: Site.current.domain)).html_safe

--- a/config/locales/de/_mailer.yml
+++ b/config/locales/de/_mailer.yml
@@ -42,7 +42,8 @@ de:
     invitation_email:
       message:
         header: "Sie wurden von <b>%{sender}</b> (%{email_sender}) eingeladen, folgender Gruppe <b>%{space}</b> beizutreten."
-        link: "Sie können diese Einladung unter folgendem Link bestätigen oder ablehnen: <br/> <a href=\"%{url}\">%{url}</a><br/><br/>Sie können mehr über diesen Gruppe hier herausfinden: <br/><a href=\"%{space_url}\">%{space_url}</a>"
+        link: "Sie können diese Einladung unter folgendem Link bestätigen oder ablehnen: <br/> <a href=\"%{url}\">%{url}</a>"
+        space_info: "Sie können mehr über diesen Gruppe hier herausfinden: <br/><a href=\"%{space_url}\">%{space_url}</a>"
         user_message: "Dies ist die Nachricht von %{sender}:"
       subject: "%{username} hat Sie eingelagen, der Gruppe %{space} beizutreten"
     join_request_email:

--- a/config/locales/en/_mailer.yml
+++ b/config/locales/en/_mailer.yml
@@ -43,7 +43,8 @@ en:
     invitation_email:
       message:
         header: "You have been invited by <b>%{sender}</b> (%{email_sender}) to join the space <b>%{space}</b>."
-        link: "You can accept or decline this invitation by clicking the link: <br/> <a href=\"%{url}\">%{url}</a><br/><br/>You can find more information about this space in the page: <br/><a href=\"%{space_url}\">%{space_url}</a>"
+        link: "You can accept or decline this invitation by clicking the link: <br/> <a href=\"%{url}\">%{url}</a>"
+        space_info: "You can find more information about this space in the page: <br/><a href=\"%{space_url}\">%{space_url}</a>"
         user_message: "This is the message written by %{sender}:"
       subject: "%{username} invited you to join the space %{space}"
     join_request_email:

--- a/config/locales/pt-br/_mailer.yml
+++ b/config/locales/pt-br/_mailer.yml
@@ -43,7 +43,8 @@ pt-br:
     invitation_email:
       message:
         header: "Você foi convidado por <b>%{sender}</b> (%{email_sender}) para participar da comunidade <b>%{space}</b>."
-        link: "Você pode aceitar ou recusar o convite clicando no link: <br/><a href=\"%{url}\">%{url}</a><br/><br/>Você pode encontrar mais informações sobre esta comunidade na página: <br/><a href=\"%{space_url}\">%{space_url}</a>"
+        link: "Você pode aceitar ou recusar o convite clicando no link: <br/><a href=\"%{url}\">%{url}</a>"
+        space_info: "Você pode encontrar mais informações sobre esta comunidade na página: <br/><a href=\"%{space_url}\">%{space_url}</a>"
         user_message: "Esta é a mensagem escrita por %{sender}:"
       subject: "%{username} convidou você para participar da comunidade %{space}"
     join_request_email:


### PR DESCRIPTION
Fixed bug #1776: Invitation to a private space shouldn't send the link to the space.