### PR TITLE
Bug1928 -  prevent events/new from being accessible to users not in a space

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -38,6 +38,8 @@ class EventsController < InheritedResources::Base
       @event.owner_name = current_user.try(:email)
     end
 
+    authorize! :new, @event
+
     new!
   end
 
@@ -97,7 +99,10 @@ class EventsController < InheritedResources::Base
   end
 
   def handle_access_denied(exception)
-    if @event.nil? || @event.owner.nil?
+    if ['new', 'create'].include? action_name
+      flash[:error] = t('flash.events.create.alert')
+      redirect_to events_path
+    elsif @event.nil? || @event.owner.nil?
       raise ActiveRecord::RecordNotFound
     else
       raise exception

--- a/app/models/abilities/member_ability.rb
+++ b/app/models/abilities/member_ability.rb
@@ -157,7 +157,10 @@ module Abilities
 
       # users can't create events in a space they don't belong to
       cannot [:create, :new], Event do |event|
-        event.owner_type == 'Space' && !event.owner.users.include?(user)
+        if event.owner_type == 'Space'
+          owner = Space.with_disabled.find(event.owner_id)
+          !owner.approved || owner.disabled || !owner.users.include?(user)
+        end
       end
 
       can [:edit, :update, :destroy, :invite, :send_invitation], Event do |e|

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,6 +4,7 @@ class Event < ActiveRecord::Base
   include PublicActivity::Common
 
   SOCIAL_NETWORKS = ['Facebook', 'Google Plus', 'Twitter', 'Linkedin']
+  OWNER_TYPES = ['Space', 'User']
 
   def self.host
     Site.current.domain
@@ -30,10 +31,11 @@ class Event < ActiveRecord::Base
   belongs_to :owner, :polymorphic => true
   has_many :participants, :dependent => :destroy
 
-  validates :name, :presence => true
-  validates :start_on, :presence => true
-  validates :time_zone, :presence => true
-  validates :summary, :length => {:maximum => 140}
+  validates :name, presence: true
+  validates :start_on, presence: true
+  validates :time_zone, presence: true
+  validates :summary, length: {:maximum => 140}
+  validates :owner, presence: true
 
   friendly_id :name, use: :slugged, :slug_column => :permalink
   validates :permalink, :presence => true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,6 @@ class Event < ActiveRecord::Base
   include PublicActivity::Common
 
   SOCIAL_NETWORKS = ['Facebook', 'Google Plus', 'Twitter', 'Linkedin']
-  OWNER_TYPES = ['Space', 'User']
 
   def self.host
     Site.current.domain

--- a/app/views/space_events/index.html.haml
+++ b/app/views/space_events/index.html.haml
@@ -15,7 +15,7 @@
 
   - if can?(:create, @space.events.build)
     #events-toolbar
-      = link_to new_event_path(:owner_id => @space.id, :owner_type => 'Space'), :class => "btn btn-primary btn-small" do
+      = link_to space_new_event_path(:space_id => @space.to_param), :class => "btn btn-primary btn-small" do
         = t('.create_event')
 
   - if params[:show] == 'past_events'

--- a/config/locales/en/_events.yml
+++ b/config/locales/en/_events.yml
@@ -37,6 +37,7 @@ en:
     events:
       create:
         notice: Successfully created the event
+        error: There was a problem creating this event
       destroy:
         notice: Successfully deleted the event
       update:

--- a/config/locales/pt-br/_events.yml
+++ b/config/locales/pt-br/_events.yml
@@ -37,6 +37,7 @@ pt-br:
     events:
       create:
         notice: Evento criado com sucesso
+        alert: Problema ao criar o evento
       destroy:
         notice: Evento apagado com sucesso
       update:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,7 @@ Mconf::Application.routes.draw do
     get '/recordings/:id/edit', to: 'spaces#edit_recording', as: 'edit_recording'
 
     get '/events', to: 'space_events#index', as: 'events'
+    get '/events/new', to: 'events#new', as: 'event_new'
 
     resources :users, only: :index
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,7 +88,7 @@ Mconf::Application.routes.draw do
     get '/recordings/:id/edit', to: 'spaces#edit_recording', as: 'edit_recording'
 
     get '/events', to: 'space_events#index', as: 'events'
-    get '/events/new', to: 'events#new', as: 'event_new'
+    get '/events/new', to: 'events#new', as: 'new_event'
 
     resources :users, only: :index
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -466,20 +466,22 @@ describe User do
 
   describe "#events", :events => true do
     let(:user) { FactoryGirl.create(:user) }
-    let(:other_user) { FactoryGirl.create(:user)}
+    let(:other_user) { FactoryGirl.create(:user) }
+    let(:another_one) { FactoryGirl.create(:user) }
 
     before(:each) do
       @events = [
       FactoryGirl.create(:event, :owner => user),
       FactoryGirl.create(:event, :owner => user),
-      FactoryGirl.create(:event, :owner => nil)
+      FactoryGirl.create(:event, :owner => other_user)
       ]
     end
 
     it { user.events.size.should eql(2) }
     it { user.events.should include(@events[0], @events[1]) }
     it { user.events.should_not include(@events[2]) }
-    it { other_user.events.should be_empty }
+    it { other_user.events.should include(@events[2]) }
+    it { another_one.events.should be_empty }
   end
 
   skip "#has_events_in_this_space?"


### PR DESCRIPTION
Also block non-approved and disabled spaces from being able to create events like this.

Added some tests and extra corrections for problems that could arise with the events(new|create) methods and all the variation with their parameters.