### PR TITLE
Bug1895 -  Cookie overflow after signing in via Shibboleth

### DIFF
--- a/app/controllers/shibboleth_controller.rb
+++ b/app/controllers/shibboleth_controller.rb
@@ -17,7 +17,6 @@ class ShibbolethController < ApplicationController
   before_filter :check_shib_enabled, :except => [:info]
   before_filter :check_current_user, :except => [:info]
   before_filter :load_shib_session
-  before_filter :save_shib_to_session, only: [:login]
   before_filter :check_shib_always_new_account, :only => [:create_association]
 
   # Log in a user using his shibboleth information
@@ -106,11 +105,7 @@ class ShibbolethController < ApplicationController
   def load_shib_session
     logger.info "Shibboleth: creating a new Mconf::Shibboleth object"
     @shib = Mconf::Shibboleth.new(session)
-  end
-
-  def save_shib_to_session
-    logger.info "Shibboleth: saving env to session"
-    @shib.save_to_session(request.env, current_site.shib_env_variables)
+    @shib.load_data(request.env, current_site.shib_env_variables)
   end
 
   # Checks if shibboleth is enabled in the current site.

--- a/app/models/ldap_token.rb
+++ b/app/models/ldap_token.rb
@@ -5,9 +5,10 @@
 # 3 or later. See the LICENSE file.
 
 class LdapToken < ActiveRecord::Base
-  # attr_accessible :data, :identifier, :user_id
   belongs_to :user
   validates :identifier, presence: true, uniqueness: true
+
+  serialize :data, Hash
 
   def self.user_created_by_ldap?(u)
     LdapToken.where(user_id: u.id, new_account: true).present?

--- a/lib/mconf/ldap.rb
+++ b/lib/mconf/ldap.rb
@@ -10,8 +10,7 @@ module Mconf
     # the root key used to store all the information in the session
     ENV_KEY = :ldap_data
 
-    # `session` is the session object where the user information will be stored
-    def initialize(session)
+    def initialize session={}
       @session = session
     end
 
@@ -46,6 +45,7 @@ module Mconf
         nil
       else
         token.user = find_account(email)
+        token.data = data_from_entry(ldap_user)
         if token.user
           Rails.logger.info "LDAP: there's already a user with this id (#{email})"
         else
@@ -66,7 +66,7 @@ module Mconf
       @session[ENV_KEY] = { username: user.username, email: user.email }
     end
 
-    # Returns whether the user is signed in via LDAP or not.
+   # Returns whether the user is signed in via LDAP or not.
     def signed_in?
       !@session.nil? && @session.has_key?(ENV_KEY)
     end
@@ -147,7 +147,11 @@ module Mconf
       [username, email, name]
     end
 
-    private
+    def data_from_entry ldap_entry
+      data = {}
+      ldap_entry.each { |k, v| data[k] = v }
+      data
+    end
 
     def create_notification(user, token)
       RecentActivity.create(

--- a/lib/mconf/shibboleth.rb
+++ b/lib/mconf/shibboleth.rb
@@ -12,18 +12,23 @@ module Mconf
 
     # `session` is the session object where the user information will be stored
     def initialize(session)
+      # Data will hold the shibolleth data which will later be saved to the DB
+      @data = {}
+
+      # This holds the session data, but will only write a boolean value to it
+      # denoting whether the user has logged in via shibboleth
       @session = session
     end
 
-    # Saves the information in the environment variables `env_variables` to the
-    # session. Uses `filters` to know which variables should be stored and which
+    # Loads the information from the environment variables `env_variables` into
+    # the object. Uses `filters` to know which variables should be stored and which
     # should be ignored.
     # `filters` is a string with one or more filters separated by '\n' or '\r\n'.
     # The filters can be a simple string or a string in the format of a regex.
     # e.g. `email\nshib-.*\r\nuid`: will get the variables that match /^email$/,
     #   /^shib-.*$/, and /^uid$/
     # If `filters` is blank, will use the default filter /^shib-/
-    def save_to_session(env_variables, filters='')
+    def load_data(env_variables, filters='')
       filter = split_into_regexes(filters)
       filter = [/^shib-/] if filter.empty?
 
@@ -34,21 +39,27 @@ module Mconf
           shib_data[key.to_s] = value
         end
       end
-      @session[ENV_KEY] = shib_data
-      Rails.logger.info "Shibboleth: info saved to session #{@session[ENV_KEY].inspect}"
+      # Saves data sent by the shib server
+      @data[ENV_KEY] ||= {}
+      @data[ENV_KEY].merge!(shib_data)
+
+      # Mark user as logged in on the session
+      @session[ENV_KEY] = true
+
+      Rails.logger.info "Shibboleth: user login to session"
       shib_data
     end
 
     # Returns whether the basic information needed for a user to login is present
     # in the session or not.
     def has_basic_info
-      @session[ENV_KEY] && get_identifier && get_email && get_name && get_principal_name
+      @data[ENV_KEY] && get_identifier && get_email && get_name && get_principal_name
     end
 
     def get_field field
       result = nil
-      if @session.has_key?(ENV_KEY)
-        result = @session[ENV_KEY][field]
+      if @data.has_key?(ENV_KEY)
+        result = @data[ENV_KEY][field]
         result = result.dup unless result.blank?
       end
       result
@@ -60,12 +71,12 @@ module Mconf
       get_principal_name
     end
 
-    # Returns the email stored in the session, if any.
+    # Returns the email stored, if any.
     def get_email
       get_field Site.current.shib_email_field
     end
 
-    # Returns the name of the user stored in the session, if any.
+    # Returns the name of the user stored, if any.
     def get_name
       get_field Site.current.shib_name_field
     end
@@ -76,29 +87,36 @@ module Mconf
       get_field Site.current.shib_principal_name_field
     end
 
-    # Returns the login of the user stored in the session, if any.
+    # Returns the login of the user, if any.
     def get_login
       get_field(Site.current.shib_login_field) || get_name # uses the name by default
     end
 
-    # Returns an unique login according to the login stored in the session.
-    # If there's no login in the session, returns nil. Otherwise will always
+    # Returns an unique login according to the login stored in the object.
+    # If there's no login, returns nil. Otherwise will always
     # return a login that doesn't exist yet.
     def get_unique_login
       Mconf::Identifier.unique_mconf_id(get_login)
     end
 
-    # Returns the shibboleth provider of the user stored in the session, if any.
+    # Returns the shibboleth provider of the user, if any.
     def get_identity_provider
       get_field 'Shib-Identity-Provider'
     end
 
     # Returns all the shibboleth data stored in the session.
     def get_data
-      @session[ENV_KEY].try(:dup)
+      @data[ENV_KEY].try(:dup)
+    end
+
+    # Sets the shibboleth data, without processing the input hash
+    # Used when reading saved user data from the session or database
+    def set_data session
+      @data[ENV_KEY] = session
     end
 
     # Returns whether the user is signed in via federation or not.
+    # Does it by reading the session data passed in to the constructor
     def signed_in?
       !@session.nil? && @session.has_key?(ENV_KEY)
     end
@@ -111,12 +129,12 @@ module Mconf
         Site.current.shib_principal_name_field ]
     end
 
-    # Finds the ShibToken associated with the user whose information is stored in the session.
+    # Finds the ShibToken associated with the user whose information is stored in the object.
     def find_token
       ShibToken.find_by_identifier(get_identifier)
     end
 
-    # Finds the ShibToken and updates it with the information in the session, unless
+    # Finds the ShibToken and updates it with the information in the object, unless
     # it's empty. Returns the token.
     # Doesn't raise an exception if it fails to save the token, will return the
     # errors in the model.
@@ -129,7 +147,7 @@ module Mconf
       token
     end
 
-    # Searches for a ShibToken using data in the session and returns it. Creates a new
+    # Searches for a ShibToken using data in the object and returns it. Creates a new
     # ShibToken if no token is found and returns it.
     def find_or_create_token
       token = find_token
@@ -141,7 +159,7 @@ module Mconf
     # Returns the User created after calling `save`. This might have errors if the call to
     # `save` failed.
     # The shib_token parameter is used as the Owner of the RecentActivity.
-    # Expects that at least the email and name will be set in the session!
+    # Expects that at least the email and name are set!
     def create_user(shib_token)
       password = SecureRandom.hex(16)
       params = {

--- a/spec/controllers/shibboleth_controller_spec.rb
+++ b/spec/controllers/shibboleth_controller_spec.rb
@@ -498,12 +498,14 @@ describe ShibbolethController do
   describe "#info" do
     before { Site.current.update_attributes(:shib_enabled => true) }
 
-    context "assigns @data with the data in the session" do
-      let(:expected) { { :one => "anything" } }
-      before { controller.session[:shib_data] = expected }
-      before(:each) { get :info }
-      it { should assign_to(:data).with(expected) }
-    end
+    # We don't read shib data from the session anymore
+    # TODO: Change the purpose of shibboleth_controller#info ?
+    # context "assigns @data with the data in the session" do
+    #   let(:expected) { { :one => "anything" } }
+    #   before { controller.session[:shib_data] = expected }
+    #   before(:each) { get :info }
+    #   it { should assign_to(:data).with(expected) }
+    # end
 
     context "renders with no layout" do
       before(:each) { get :info }
@@ -526,7 +528,7 @@ describe ShibbolethController do
   # Save it to the session, as #login would do
   def save_shib_to_session
     @shib = Mconf::Shibboleth.new(session)
-    @shib.save_to_session(request.env)
+    @shib.load_data(request.env)
   end
 
 end

--- a/spec/factories/ldap_token.rb
+++ b/spec/factories/ldap_token.rb
@@ -7,7 +7,7 @@
 FactoryGirl.define do
   factory :ldap_token do
     association :user, factory: :user
-    data "MyText"
+    data {}
     after(:build) do |obj|
       obj.identifier = obj.user.email
     end

--- a/spec/lib/mconf/shibboleth_spec.rb
+++ b/spec/lib/mconf/shibboleth_spec.rb
@@ -19,105 +19,104 @@ describe Mconf::Shibboleth do
     end
   end
 
-  describe "#save_to_session" do
+  describe "#load_data" do
     let(:session) { {} }
     let(:shibboleth) { Mconf::Shibboleth.new(session) }
 
     context "saves the variables in the environment to the session" do
       let(:env) { { :'shib-var1' => 'first', :'shib-var2' => 'second' } }
-      before { shibboleth.save_to_session(env) }
-      it { session.length.should be(1) }
-      it { session.should have_key(:shib_data) }
-      it { session[:shib_data].length.should be(2) }
-      it { session[:shib_data].should have_key('shib-var1') }
-      it { session[:shib_data]['shib-var1'].should eq('first') }
-      it { session[:shib_data].should have_key('shib-var2') }
-      it { session[:shib_data]['shib-var2'].should eq('second') }
+      before { shibboleth.load_data(env) }
+      it { shibboleth.get_data.length.should be() }
+      it { shibboleth.get_data.length.should be(2) }
+      it { shibboleth.get_data.should have_key('shib-var1') }
+      it { shibboleth.get_data['shib-var1'].should eq('first') }
+      it { shibboleth.get_data.should have_key('shib-var2') }
+      it { shibboleth.get_data['shib-var2'].should eq('second') }
     end
 
     context "if no filters are passed, uses /^shib-/" do
       let(:env) { { :'shib-var1' => 'first', :anything => 'anything', :'other-shib-invalid' => 'anything' } }
-      before { shibboleth.save_to_session(env) }
-      it { session[:shib_data].length.should be(1) }
-      it { session[:shib_data].should have_key('shib-var1') }
-      it { session[:shib_data]['shib-var1'].should eq('first') }
+      before { shibboleth.load_data(env) }
+      it { shibboleth.get_data.length.should be(1) }
+      it { shibboleth.get_data.should have_key('shib-var1') }
+      it { shibboleth.get_data['shib-var1'].should eq('first') }
     end
 
     context "accepts string filters" do
       let(:env) { { :first => 'first', :second => 'second' } }
-      before { shibboleth.save_to_session(env, 'second') }
-      it { session[:shib_data].length.should be(1) }
-      it { session[:shib_data].should have_key('second') }
-      it { session[:shib_data]['second'].should eq('second') }
+      before { shibboleth.load_data(env, 'second') }
+      it { shibboleth.get_data.length.should be(1) }
+      it { shibboleth.get_data.should have_key('second') }
+      it { shibboleth.get_data['second'].should eq('second') }
     end
 
     context "string with encoding ASCII-8BIT" do
       let(:env) { { :first => 'first', :second => 'çÃïçáõ'.force_encoding("ASCII-8BIT") } }
-      before { shibboleth.save_to_session(env, 'second')}
-      it { session[:shib_data].length.should be(1) }
-      it { session[:shib_data].should have_key('second') }
-      it { session[:shib_data]['second'].should eq('çÃïçáõ') }
+      before { shibboleth.load_data(env, 'second')}
+      it { shibboleth.get_data.length.should be(1) }
+      it { shibboleth.get_data.should have_key('second') }
+      it { shibboleth.get_data['second'].should eq('çÃïçáõ') }
     end
 
     context "accepts keys as strings" do
       let(:env) { { 'first' => 'first', 'second' => 'second' } }
-      before { shibboleth.save_to_session(env, 'second') }
-      it { session[:shib_data].length.should be(1) }
-      it { session[:shib_data].should have_key('second') }
-      it { session[:shib_data]['second'].should eq('second') }
+      before { shibboleth.load_data(env, 'second') }
+      it { shibboleth.get_data.length.should be(1) }
+      it { shibboleth.get_data.should have_key('second') }
+      it { shibboleth.get_data['second'].should eq('second') }
     end
 
     context "accepts regex filters" do
       let(:env) { { :any_one => 'first', :any_two => 'second', :other_any => 'third' } }
-      before { shibboleth.save_to_session(env, 'any.*') }
-      it { session[:shib_data].length.should be(2) }
-      it { session[:shib_data].should have_key('any_one') }
-      it { session[:shib_data]['any_one'].should eq('first') }
-      it { session[:shib_data].should have_key('any_two') }
-      it { session[:shib_data]['any_two'].should eq('second') }
+      before { shibboleth.load_data(env, 'any.*') }
+      it { shibboleth.get_data.length.should be(2) }
+      it { shibboleth.get_data.should have_key('any_one') }
+      it { shibboleth.get_data['any_one'].should eq('first') }
+      it { shibboleth.get_data.should have_key('any_two') }
+      it { shibboleth.get_data['any_two'].should eq('second') }
     end
 
     context "transform filters into exact regexes" do
       let(:env) { { :pre => 'first', :prefix => 'second', :preamble => 'third' } }
-      before { shibboleth.save_to_session(env, 'pre') }
-      it { session[:shib_data].length.should be(1) }
-      it { session[:shib_data].should have_key('pre') }
-      it { session[:shib_data]['pre'].should eq('first') }
+      before { shibboleth.load_data(env, 'pre') }
+      it { shibboleth.get_data.length.should be(1) }
+      it { shibboleth.get_data.should have_key('pre') }
+      it { shibboleth.get_data['pre'].should eq('first') }
     end
 
     context "accepts multiple filters separated by '\\n' or '\\r\\n'" do
       let(:env) { { :first => 'first', :second => 'second', :second_b => 'second_b', :third => 'third', :fourth => 'fourth' } }
-      before { shibboleth.save_to_session(env, "first\nsecond.*\r\nthird") }
-      it { session[:shib_data].length.should be(4) }
-      it { session[:shib_data].should have_key('first') }
-      it { session[:shib_data]['first'].should eq('first') }
-      it { session[:shib_data].should have_key('second') }
-      it { session[:shib_data]['second'].should eq('second') }
-      it { session[:shib_data].should have_key('second_b') }
-      it { session[:shib_data]['second_b'].should eq('second_b') }
-      it { session[:shib_data].should have_key('third') }
-      it { session[:shib_data]['third'].should eq('third') }
+      before { shibboleth.load_data(env, "first\nsecond.*\r\nthird") }
+      it { shibboleth.get_data.length.should be(4) }
+      it { shibboleth.get_data.should have_key('first') }
+      it { shibboleth.get_data['first'].should eq('first') }
+      it { shibboleth.get_data.should have_key('second') }
+      it { shibboleth.get_data['second'].should eq('second') }
+      it { shibboleth.get_data.should have_key('second_b') }
+      it { shibboleth.get_data['second_b'].should eq('second_b') }
+      it { shibboleth.get_data.should have_key('third') }
+      it { shibboleth.get_data['third'].should eq('third') }
     end
 
     context "ignores cases in the filters" do
       let(:env) { { :firsT => 'first', :second => 'second' } }
-      before { shibboleth.save_to_session(env, 'FiRsT') }
-      it { session[:shib_data].length.should be(1) }
-      it { session[:shib_data].should have_key('firsT') }
-      it { session[:shib_data]['firsT'].should eq('first') }
+      before { shibboleth.load_data(env, 'FiRsT') }
+      it { shibboleth.get_data.length.should be(1) }
+      it { shibboleth.get_data.should have_key('firsT') }
+      it { shibboleth.get_data['firsT'].should eq('first') }
     end
 
     context "ignores white spaces in the front and end of filters" do
       let(:env) { { :first => 'first', :second => 'second' } }
-      before { shibboleth.save_to_session(env, '   first   ') }
-      it { session[:shib_data].length.should be(1) }
-      it { session[:shib_data].should have_key('first') }
-      it { session[:shib_data]['first'].should eq('first') }
+      before { shibboleth.load_data(env, '   first   ') }
+      it { shibboleth.get_data.length.should be(1) }
+      it { shibboleth.get_data.should have_key('first') }
+      it { shibboleth.get_data['first'].should eq('first') }
     end
 
     context "returns the data stored in the session" do
       let(:env) { { :first => 'first', :second => 'second' } }
-      before { @result = shibboleth.save_to_session(env, "first\nsecond") }
+      before { @result = shibboleth.load_data(env, "first\nsecond") }
       it { @result.length.should be(2) }
       it { @result.should have_key('first') }
       it { @result['first'].should eq('first') }
@@ -138,6 +137,8 @@ describe Mconf::Shibboleth do
     context "when there's shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new(session) }
       before {
+        shibboleth.set_data(session[:shib_data])
+
         Site.current.update_attributes(:shib_email_field => 'email',
                                        :shib_name_field => 'name',
                                        :shib_principal_name_field => 'principal_name')
@@ -170,12 +171,14 @@ describe Mconf::Shibboleth do
   describe "#get_email" do
     context "returns nil if there's no shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new({}) }
+      before { shibboleth.load_data({}) }
       subject { shibboleth.get_email }
       it { should be_nil }
     end
 
     context "when there's shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new(session) }
+      before { shibboleth.set_data(session[:shib_data]) }
 
       context "returns the email pointed by the site's 'shib_email_field'" do
         let(:session) { { :shib_data => { 'email' => 'my-email@anything' } } }
@@ -225,12 +228,14 @@ describe Mconf::Shibboleth do
   describe "#get_name" do
     context "returns nil if there's no shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new({}) }
+      before { shibboleth.set_data({}) }
       subject { shibboleth.get_name }
       it { should be_nil }
     end
 
     context "when there's shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new(session) }
+      before { shibboleth.set_data(session[:shib_data]) }
 
       context "returns the name pointed by the site's 'shib_name_field'" do
         let(:session) { { :shib_data => { 'name' => 'my-name' } } }
@@ -279,12 +284,14 @@ describe Mconf::Shibboleth do
   describe "#get_principal_name" do
     context "returns nil if there's no shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new({}) }
+      before { shibboleth.set_data({}) }
       subject { shibboleth.get_principal_name }
       it { should be_nil }
     end
 
     context "when there's shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new(session) }
+      before { shibboleth.set_data(session[:shib_data]) }
 
       context "returns the name pointed by the site's 'shib_principal_name_field'" do
         let(:session) { { :shib_data => { 'principal_name' => 'my-name' } } }
@@ -333,12 +340,14 @@ describe Mconf::Shibboleth do
   describe "#get_login" do
     context "returns nil if there's no shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new({}) }
+      before { shibboleth.set_data({}) }
       subject { shibboleth.get_login }
       it { should be_nil }
     end
 
     context "when there's shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new(session) }
+      before { shibboleth.set_data(session[:shib_data]) }
 
       context "returns the login pointed by the site's 'shib_login_field'" do
         let(:session) { { :shib_data => { 'login' => 'my-login' } } }
@@ -386,12 +395,14 @@ describe Mconf::Shibboleth do
   describe "#get_identity_provider" do
     context "returns nil if there's no shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new({}) }
+      before { shibboleth.set_data({}) }
       subject { shibboleth.get_identity_provider }
       it { should be_nil }
     end
 
     context "when there's shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new(session) }
+      before { shibboleth.set_data(session[:shib_data]) }
 
       context "returns the identity provider using a default key" do
         let(:session) { { :shib_data => { 'Shib-Identity-Provider' => 'my-idp' } } }
@@ -424,13 +435,16 @@ describe Mconf::Shibboleth do
   describe "#get_data" do
     context "returns nil if there's no shib data in the session" do
       let(:shibboleth) { Mconf::Shibboleth.new({}) }
+      before { shibboleth.set_data({}) }
       subject { shibboleth.get_data }
-      it { should be_nil }
+      it { should be_blank }
     end
 
     context "returns the data when there's shib data in the session" do
       let(:session) { { :shib_data => { 'first' => 'any', 'second' => 'other' } } }
       let(:shibboleth) { Mconf::Shibboleth.new(session) }
+      before { shibboleth.set_data(session[:shib_data]) }
+
       subject { shibboleth.get_data }
       it { should eq(session[:shib_data]) }
     end
@@ -451,6 +465,8 @@ describe Mconf::Shibboleth do
 
     context "if the session has :shib_data key" do
       let(:shibboleth) { Mconf::Shibboleth.new({ :shib_data => {} }) }
+      before { shibboleth.set_data({}) }
+
       subject { shibboleth.signed_in? }
       it { should be_truthy }
     end
@@ -526,6 +542,8 @@ describe Mconf::Shibboleth do
       before {
         ShibToken.create!(identifier: 'any@email.com', user: user, data: old_data)
         shibboleth.should_receive(:get_identifier).and_return('any@email.com')
+
+        shibboleth.set_data(new_data)
       }
       subject {
         token = shibboleth.find_and_update_token
@@ -542,6 +560,8 @@ describe Mconf::Shibboleth do
       before {
         ShibToken.create!(identifier: 'any@email.com', user: user, data: old_data)
         shibboleth.should_receive(:get_identifier).and_return('any@email.com')
+
+        shibboleth.set_data(new_data)
       }
       subject {
         token = shibboleth.find_and_update_token


### PR DESCRIPTION
A few thinks here:

 * Don't store all the shibboleth env variables in the session cookie, just a flag denoting the user has logged in via shibboleth after the whole process is done
 * Store extra DB information for LDAP users. This is here so that in users#edit we can show similar results for LDAP and Shib in the future.

Some tests dont make sense now that we don't store as much information in the session cookie, in the future we should think about rewriting or removing them.