### PR TITLE
Explicit file type accepts in upload forms

### DIFF
--- a/app/assets/javascripts/app/application/uploader.js.coffee
+++ b/app/assets/javascripts/app/application/uploader.js.coffee
@@ -76,7 +76,7 @@ class mconf.Uploader
       validation: {}
 
     if element.attr('data-accept')
-      options.validation.allowedExtensions = getFormatsFromAccept(element.attr('data-accept'))
+      options.validation.allowedExtensions = getAcceptedFormats(element.attr('data-accept'))
       options.validation.acceptFiles = element.attr('data-accept')
 
     if element.attr('data-max-size')
@@ -84,11 +84,7 @@ class mconf.Uploader
 
     uploader = new qq.FineUploader(options)
 
-getFormatsFromAccept = (accept) ->
-  if accept? && accept == 'image/*'
-    ['jpg', 'jpeg', 'png']
+getAcceptedFormats = (accept) ->
+  formats = accept.split(',')
 
-# Use this when firefox is ready to use the accepts='.jpg,.png, ...' (version 37 maybe)
-getFileTypesFromAccept = (accept) ->
-  formats = ('.' + format for format in getFormatsFromAccept(accept))
-  formats.join(',')
+  format.replace('.', '') for format in formats

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -35,7 +35,9 @@ class ProfilesController < ApplicationController
         }
       end
     else
-      format.json { render json: { success: false } }
+      respond_to do |format|
+        format.json { render json: { success: false } }
+      end
     end
   end
 

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -101,7 +101,9 @@ class SpacesController < InheritedResources::Base
         }
       end
     else
-      format.json { render json: { success: false } }
+      respond_to do |format|
+        format.json { render json: { success: false } }
+      end
     end
   end
 

--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -11,7 +11,7 @@
     #edit-profile-current-logo
       = logo_image(@user, :size => '128', :class => 'profile-logo logo logo-uploadable')
     %ul
-      #profile-logo-uploader.file-uploader{:'data-endpoint' => update_logo_user_profile_path(@user, :format => :json), :'data-accept' => 'image/*', :'data-max-size' => max_upload_size }
+      #profile-logo-uploader.file-uploader{:'data-endpoint' => update_logo_user_profile_path(@user, :format => :json), :'data-accept' => '.jpg,.jpeg,.png', :'data-max-size' => max_upload_size }
       %li
         = simple_form_for @profile, :url => user_profile_path(@user), :html => { :multipart => true, :method => :put } do |f|
           = link_to t('.vcard.use'), '#profile_vcard', :"data-open-file" => true

--- a/app/views/spaces/edit.html.haml
+++ b/app/views/spaces/edit.html.haml
@@ -11,7 +11,7 @@
     #edit-space-current-logo
       = logo_image(@space, :size => '168x128', :class => 'logo logo-uploadable')
 
-      #space-logo-uploader.file-uploader{:'data-endpoint' => update_logo_space_path(@space, :format => :json), :'data-accept' => 'image/*', :'data-max-size' => max_upload_size }
+      #space-logo-uploader.file-uploader{:'data-endpoint' => update_logo_space_path(@space, :format => :json), :'data-accept' => '.jpg,.jpeg,.png', :'data-max-size' => max_upload_size }
 
   = simple_form_for @space, :html => { :method => :put, :class => 'single-column' } do |f|
     .left-column


### PR DESCRIPTION
This way of doing things only shows valid upload types and makes things look relatively good in Chrome and Firefox

Also correct a line in upload_logo which would cause an error if the uploader failed to update the model (not a big deal :)

Solves bugs #501 and #353.