### PR TITLE
Changed pending page redirect verification

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -55,9 +55,10 @@ class MyController < ApplicationController
   end
 
   def approval_pending
-    # don't show it unless user is coming from a login or register
-    referers = [new_user_session_url, login_url, register_url, root_url, shibboleth_url]
-    if user_signed_in? || !referers.include?(request.referrer)
+    # don't show it unless user is coming from a login or register (even if he has been to another site meanwhile,
+    # like when shibboleth sends him to the federation site)
+    referers = [new_user_session_path, login_path, register_path, root_path, shibboleth_path]
+    if  user_signed_in? || !referers.include?(session[:user_return_to])
       redirect_to root_path
     end
   end


### PR DESCRIPTION
 Now instead of getting the request referer, the test will be over the last referer on mconf-web site
 This should allow users to go to the federation portal and then back to pending page every time

resolves #877 