### PR TITLE
Changed pending page redirect verification

### DIFF
--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -55,10 +55,9 @@ class MyController < ApplicationController
   end
 
   def approval_pending
-    # don't show it unless user is coming from a login or register (even if he has been to another site meanwhile,
-    # like when shibboleth sends him to the federation site)
-    referers = [new_user_session_path, login_path, register_path, root_path, shibboleth_path]
-    if  user_signed_in? || !referers.include?(session[:user_return_to])
+    # don't show it unless user is coming from a login or register
+    referers = [new_user_session_url, login_url, register_url, root_url, shibboleth_url]
+    if  user_signed_in? || (!referers.include?(request.referrer) && !session[:shib_login])
       redirect_to root_path
     end
   end

--- a/app/controllers/my_controller.rb
+++ b/app/controllers/my_controller.rb
@@ -55,9 +55,10 @@ class MyController < ApplicationController
   end
 
   def approval_pending
-    # don't show it unless user is coming from a login or register
-    referers = [new_user_session_url, login_url, register_url, root_url, shibboleth_url]
-    if user_signed_in? || !referers.include?(request.referrer)
+    # don't show it unless user is coming from a login or register (even if he has been to another site meanwhile,
+    # like when shibboleth sends him to the federation site)
+    referers = [new_user_session_path, login_path, register_path, root_path, shibboleth_path]
+    if  user_signed_in? || !referers.include?(session[:user_return_to])
       redirect_to root_path
     end
   end

--- a/spec/features/site/flag_require_registration_approval_spec.rb
+++ b/spec/features/site/flag_require_registration_approval_spec.rb
@@ -64,6 +64,7 @@ feature 'Behaviour of the flag Site#require_registration_approval' do
 
         with_resque do
           expect {
+            visit "http://www.google.com"
             visit shibboleth_path
             click_button t('shibboleth.associate.new_account.create_new_account')
           }.to change{ User.count }.by(1)


### PR DESCRIPTION
we are now using the shibboleth login flag which resolves the problem, detects that the user is coming from Shibboleth login and should see the pending page.

also changed the spec test to ensure the user left the page (which happens when using federation login) and then came back, now it catches the bug described in #877 

resolves #877