### PR TITLE
Changed the Queues of Resque from "types of work" to priorities

### DIFF
--- a/app/workers/base_worker.rb
+++ b/app/workers/base_worker.rb
@@ -3,6 +3,9 @@
 #
 # This file is licensed under the Affero General Public License version
 # 3 or later. See the LICENSE file.
+require './lib/mconf/mconf_resque_high'
+require './lib/mconf/mconf_resque_normal'
+require './lib/mconf/mconf_resque_low'
 
 class BaseWorker
   # Make everyone who inherits from BaseWorker an exclusive lock worker

--- a/app/workers/invitation_sender_worker.rb
+++ b/app/workers/invitation_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class InvitationSenderWorker < BaseWorker
-  @queue = :invitations
 
   # Finds the target notification and sends it. Marks it as notified.
   def self.perform(invitation_id)

--- a/app/workers/invitations_worker.rb
+++ b/app/workers/invitations_worker.rb
@@ -8,7 +8,6 @@
 # Finds all Invitation objects not sent yet and ready to be sent and schedules a
 # worker to send them.
 class InvitationsWorker < BaseWorker
-  @queue = :invitations
 
   def self.perform
     all_invitations
@@ -17,7 +16,7 @@ class InvitationsWorker < BaseWorker
   def self.all_invitations
     invitations = Invitation.where sent: false, ready: true
     invitations.each do |invitation|
-      Resque.enqueue(InvitationSenderWorker, invitation.id)
+      Queue::High.enqueue(InvitationSenderWorker, :perform, invitation.id)
     end
   end
 

--- a/app/workers/join_request_invite_sender_worker.rb
+++ b/app/workers/join_request_invite_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class JoinRequestInviteSenderWorker < BaseWorker
-  @queue = :join_requests
 
   # Finds the join request associated with the activity in `activity_id` and sends
   # a notification to the user that he/she was invited to join the space.

--- a/app/workers/join_request_sender_worker.rb
+++ b/app/workers/join_request_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class JoinRequestSenderWorker < BaseWorker
-  @queue = :join_requests
 
   # Finds the join request associated with the activity in `activity_id` and sends
   # a notification to the admins of the space that a user wants to join the space.

--- a/app/workers/join_request_user_added_sender_worker.rb
+++ b/app/workers/join_request_user_added_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class JoinRequestUserAddedSenderWorker < BaseWorker
-  @queue = :join_requests
 
   def self.perform(activity_id)
     activity = RecentActivity.find(activity_id)

--- a/app/workers/join_requests_worker.rb
+++ b/app/workers/join_requests_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class JoinRequestsWorker < BaseWorker
-  @queue = :join_requests
 
   # Finds all join requests with pending notifications and sends them
   def self.perform
@@ -21,7 +20,7 @@ class JoinRequestsWorker < BaseWorker
   def self.invite_notifications
     invites = RecentActivity.where trackable_type: 'JoinRequest', key: 'join_request.invite', notified: [nil,false]
     invites.each do |activity|
-      Resque.enqueue(JoinRequestInviteSenderWorker, activity.id)
+      Queue::High.enqueue(JoinRequestInviteSenderWorker, :perform, activity.id)
     end
   end
 
@@ -30,7 +29,7 @@ class JoinRequestsWorker < BaseWorker
   def self.request_notifications
     requests = RecentActivity.where trackable_type: 'JoinRequest', key: 'join_request.request', notified: [nil,false]
     requests.each do |activity|
-      Resque.enqueue(JoinRequestSenderWorker, activity.id)
+      Queue::High.enqueue(JoinRequestSenderWorker, :perform, activity.id)
     end
   end
 
@@ -46,7 +45,7 @@ class JoinRequestsWorker < BaseWorker
     end
 
     requests.each do |activity|
-      Resque.enqueue(ProcessedJoinRequestSenderWorker, activity.id)
+      Queue::High.enqueue(ProcessedJoinRequestSenderWorker, :perform, activity.id)
     end
   end
 
@@ -54,7 +53,7 @@ class JoinRequestsWorker < BaseWorker
     joins = RecentActivity.where trackable_type: 'JoinRequest', key: ['join_request.no_accept'], notified: [nil, false]
 
     joins.each do |activity|
-      Resque.enqueue(JoinRequestUserAddedSenderWorker, activity.id)
+      Queue::High.enqueue(JoinRequestUserAddedSenderWorker, :perform, activity.id)
     end
   end
 end

--- a/app/workers/participant_confirmations_sender_worker.rb
+++ b/app/workers/participant_confirmations_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class ParticipantConfirmationsSenderWorker < BaseWorker
-  @queue = :participant_confirmations
 
   # Sends a notification to the user with id `user_id` that he was approved.
   def self.perform(pc_id)

--- a/app/workers/participant_confirmations_worker.rb
+++ b/app/workers/participant_confirmations_worker.rb
@@ -6,13 +6,12 @@
 # 3 or later. See the LICENSE file.
 
 class ParticipantConfirmationsWorker < BaseWorker
-  @queue = :participant_confirmations
 
   # Finds all unsent participant confirmations
   def self.perform
     confirmations = ParticipantConfirmation.where(email_sent_at: [nil])
     confirmations.each do |confirmation|
-      Resque.enqueue(ParticipantConfirmationsSenderWorker, confirmation.id)
+      Queue::High.enqueue(ParticipantConfirmationsSenderWorker, :perform, confirmation.id)
     end
   end
 end

--- a/app/workers/processed_join_request_sender_worker.rb
+++ b/app/workers/processed_join_request_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class ProcessedJoinRequestSenderWorker < BaseWorker
-  @queue = :join_requests
 
   # Finds the join request associated with the activity in `activity_id` and sends
   # a notification to the users that the join request was accepted/declined.

--- a/app/workers/space_approved_sender_worker.rb
+++ b/app/workers/space_approved_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class SpaceApprovedSenderWorker < BaseWorker
-  @queue = :space_notifications
 
   # Sends a notification to the space creator and all admins that the space with id `space_id` was approved.
   def self.perform(activity_id)

--- a/app/workers/space_needs_approval_sender_worker.rb
+++ b/app/workers/space_needs_approval_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class SpaceNeedsApprovalSenderWorker < BaseWorker
-  @queue = :space_notifications
 
   # Sends a notification to all recipients in the array of ids `recipient_ids`
   # informing that the space with id `space_id` needs to be approved.

--- a/app/workers/update_space_relevance_indexes_worker.rb
+++ b/app/workers/update_space_relevance_indexes_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class UpdateSpaceRelevanceIndexesWorker < BaseWorker
-  @queue = :update_space_relevance_indexes
 
   def self.perform
     Resque.logger.info "* [space_indexes] Updating space relevance indexes."

--- a/app/workers/user_approved_sender_worker.rb
+++ b/app/workers/user_approved_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class UserApprovedSenderWorker < BaseWorker
-  @queue = :user_notifications
 
   # Sends a notification to the user with id `user_id` that he was approved.
   def self.perform(activity_id)

--- a/app/workers/user_needs_approval_sender_worker.rb
+++ b/app/workers/user_needs_approval_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class UserNeedsApprovalSenderWorker < BaseWorker
-  @queue = :user_notifications
 
   # Sends a notification to all recipients in the array of ids `recipient_ids`
   # informing that the user with id `user_id` needs to be approved.

--- a/app/workers/user_notifications_worker.rb
+++ b/app/workers/user_notifications_worker.rb
@@ -8,7 +8,6 @@
 # Finds all Invitation objects not sent yet and ready to be sent and schedules a
 # worker to send them.
 class UserNotificationsWorker < BaseWorker
-  @queue = :user_notifications
 
   def self.perform
     notify_users_account_created
@@ -38,7 +37,7 @@ class UserNotificationsWorker < BaseWorker
           if user.approved?
             activity.update_attribute(:notified, true)
           else
-            Resque.enqueue(UserNeedsApprovalSenderWorker, activity.id, recipients)
+            Queue::High.enqueue(UserNeedsApprovalSenderWorker, :perform, activity.id, recipients)
           end
         end
       end
@@ -55,7 +54,7 @@ class UserNotificationsWorker < BaseWorker
     activities = RecentActivity
       .where(trackable_type: 'User', notified: [nil, false], key: keys)
     activities.each do |activity|
-      Resque.enqueue(UserRegisteredSenderWorker, activity.id)
+      Queue::High.enqueue(UserRegisteredSenderWorker, :perform, activity.id)
     end
   end
 
@@ -65,7 +64,7 @@ class UserNotificationsWorker < BaseWorker
     activities = RecentActivity
       .where(trackable_type: 'User', notified: [nil, false], key: 'user.created_by_admin')
     activities.each do |activity|
-      Resque.enqueue(UserRegisteredByAdminSenderWorker, activity.id)
+      Queue::High.enqueue(UserRegisteredByAdminSenderWorker, :perform, activity.id)
     end
   end
 
@@ -75,7 +74,7 @@ class UserNotificationsWorker < BaseWorker
     activities = RecentActivity
       .where trackable_type: 'User', key: 'user.approved', notified: [nil, false]
     activities.each do |activity|
-      Resque.enqueue(UserApprovedSenderWorker, activity.id)
+      Queue::High.enqueue(UserApprovedSenderWorker, :perform, activity.id)
     end
   end
 

--- a/app/workers/user_registered_by_admin_sender_worker.rb
+++ b/app/workers/user_registered_by_admin_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class UserRegisteredByAdminSenderWorker < BaseWorker
-  @queue = :user_notifications
 
   # Sends a notification to the user with id `user_id` that he was registered successfully.
   def self.perform(activity_id)

--- a/app/workers/user_registered_sender_worker.rb
+++ b/app/workers/user_registered_sender_worker.rb
@@ -6,7 +6,6 @@
 # 3 or later. See the LICENSE file.
 
 class UserRegisteredSenderWorker < BaseWorker
-  @queue = :user_notifications
 
   # Sends a notification to the user with id `user_id` that he was registered successfully.
   def self.perform(activity_id)

--- a/config/workers_schedule.yml
+++ b/config/workers_schedule.yml
@@ -2,51 +2,60 @@ send_join_requests_notifications:
   every:
     - "30s"
   class: JoinRequestsWorker
+  queue: high
   description: "Sends notifications for all join requests not notified yet"
 
 send_invitations:
   every:
     - "30s"
   class: InvitationsWorker
+  queue: high
   description: "Finds all invitations still not sent and sends them"
 
 send_user_notifications:
   every:
     - "30s"
   class: UserNotificationsWorker
+  queue: high
   description: "Checks pending user notifications and sends them"
 
 send_space_notifications:
   every:
     - "30s"
   class: SpaceNotificationsWorker
+  queue: high
   description: "Checks pending space notifications and sends them"
 
 send_participant_confirmations_notifications:
   every:
     - "30s"
   class: ParticipantConfirmationsWorker
+  queue: normal
   description: "Checks pending event confirmations email and sends them"
 
 finish_meetings:
   every:
     - "30s"
   class: BigbluebuttonFinishMeetings
+  queue: low
   description: "Checks for meetings that finished and mark as finished. Same as 'rake bigbluebutton_rails:meetings:finish'."
 
 update_recordings:
   every:
     - "30m"
   class: BigbluebuttonUpdateRecordings
+  queue: low
   description: "Gets the recordings in the server to populate the db. Same as 'rake bigbluebutton_rails:recordings:update'."
 
 update_server_configs:
   every:
     - "1h"
   class: BigbluebuttonUpdateServerConfigs
+  queue: low
   description: "Updates the server configs that are stored locally. Same as 'rake bigbluebutton_rails:server_configs:update'."
 
 update_space_relevance_indexes:
    cron: "0 4 * * *" # daily at 4am
    class: UpdateSpaceRelevanceIndexesWorker
+   queue: low
    description: "Recalculate and update indexes used for ordering spaces in the spaces#index page."

--- a/lib/mconf/mconf_resque.rb
+++ b/lib/mconf/mconf_resque.rb
@@ -1,0 +1,30 @@
+class Queue::Mconf
+
+  class << self
+
+    def enqueue(object, method, *args)
+
+      meta = { 'method' => method }
+    
+      if is_model?(object)
+        Resque.enqueue(self, meta.merge('class' => object.class.name, 'id' => object.id), *args)
+      else
+        Resque.enqueue(self, meta.merge('class' => object.name), *args)
+      end
+    end
+
+    def perform(meta = { }, *args)
+      if meta.has_key?('id')
+        if model = meta['class'].constantize.find_by_id(meta['id'])
+          model.send(meta['method'], *args)
+        end
+      else
+        meta['class'].constantize.send(meta['method'], *args)
+      end
+    end
+
+    def is_model?(object)
+      object.class.respond_to?(:find_by_id)
+    end
+  end
+end

--- a/lib/mconf/mconf_resque_high.rb
+++ b/lib/mconf/mconf_resque_high.rb
@@ -1,0 +1,5 @@
+require './lib/mconf/mconf_resque'
+class Queue::High < Queue::Mconf
+  @queue = :high
+end
+

--- a/lib/mconf/mconf_resque_low.rb
+++ b/lib/mconf/mconf_resque_low.rb
@@ -1,0 +1,4 @@
+require './lib/mconf/mconf_resque'
+class Queue::Low < Queue::Mconf
+  @queue = :low
+end

--- a/lib/mconf/mconf_resque_normal.rb
+++ b/lib/mconf/mconf_resque_normal.rb
@@ -1,0 +1,5 @@
+require './lib/mconf/mconf_resque'
+class Queue::Normal < Queue::Mconf
+  @queue = :normal
+end
+

--- a/script/start_resque_workers.sh
+++ b/script/start_resque_workers.sh
@@ -37,7 +37,7 @@ cd $APP_PATH
 if [ "$1" != "stop" ]; then
   if [ "$2" == "all" ]; then
     # for all queues
-    /usr/bin/env bundle exec rake environment resque:work RAILS_ENV=$RAILS_ENV PIDFILE=$PIDFILE QUEUE="*" TERM_CHILD=1 >> $LOGFILE 2>&1 &
+    /usr/bin/env bundle exec rake environment resque:work RAILS_ENV=$RAILS_ENV PIDFILE=$PIDFILE QUEUE="mailer, high, bigbluebutton_rails, normal, low" TERM_CHILD=1 >> $LOGFILE 2>&1 &
   else
     # for specific queues
     /usr/bin/env bundle exec rake environment resque:work RAILS_ENV=$RAILS_ENV PIDFILE=$PIDFILE QUEUE=$2 TERM_CHILD=1 >> $LOGFILE 2>&1 &

--- a/spec/workers/invitation_sender_worker_spec.rb
+++ b/spec/workers/invitation_sender_worker_spec.rb
@@ -9,10 +9,6 @@ require 'spec_helper'
 describe InvitationSenderWorker, type: :worker do
   let(:worker) { InvitationSenderWorker }
 
-  it "uses the queue :join_requests" do
-    worker.instance_variable_get(:@queue).should eql(:invitations)
-  end
-
   describe "#perform" do
 
     context "sends the invitation and marks as sent" do

--- a/spec/workers/invitations_worker_spec.rb
+++ b/spec/workers/invitations_worker_spec.rb
@@ -8,44 +8,43 @@ require 'spec_helper'
 
 describe InvitationsWorker, type: :worker do
   let(:worker) { InvitationsWorker }
-
-  it "uses the queue :join_requests" do
-    worker.instance_variable_get(:@queue).should eql(:invitations)
-  end
+  let(:sender) { InvitationSenderWorker }
+  let(:queue) { Queue::High }
+  let(:params) {{"method"=>:perform, "class"=>sender.to_s}}
 
   describe "#perform" do
 
-    describe "queues unsent invitations for web conferences and events" do
+    describe "queues unsent invitations for web conferences and events in the specified queue" do
       let!(:invitation_conference) { FactoryGirl.create(:web_conference_invitation, :sent => false, :ready => true) }
       let!(:invitation_event) { FactoryGirl.create(:event_invitation, :sent => false, :ready => true) }
 
       before(:each) { worker.perform }
 
-      it { expect(InvitationSenderWorker).to have_queue_size_of(2) }
-      it { expect(InvitationSenderWorker).to have_queued(invitation_conference.id) }
-      it { expect(InvitationSenderWorker).to have_queued(invitation_event.id) }
+      it { expect(queue).to have_queue_size_of(2) }
+      it { expect(queue).to have_queued(params, invitation_conference.id) }
+      it { expect(queue).to have_queued(params, invitation_event.id) }
     end
 
-    describe "doesn't queue unready invitations" do
+    describe "doesn't queue unready invitations in the specified queue" do
       let!(:invitation_ready) { FactoryGirl.create(:web_conference_invitation, :sent => false, :ready => true) }
       let!(:invitation_not_ready) { FactoryGirl.create(:web_conference_invitation, :sent => false, :ready => false) }
 
       before(:each) { worker.perform }
 
-      it { expect(InvitationSenderWorker).to have_queue_size_of(1) }
-      it { expect(InvitationSenderWorker).to have_queued(invitation_ready.id) }
-      it { expect(InvitationSenderWorker).not_to have_queued(invitation_not_ready.id) }
+      it { expect(queue).to have_queue_size_of(1) }
+      it { expect(queue).to have_queued(params, invitation_ready.id) }
+      it { expect(queue).not_to have_queued(params, invitation_not_ready.id) }
     end
 
-    describe "doesn't queue already sent invitations" do
+    describe "doesn't queue already sent invitations in the specified queue" do
       let!(:invitation_sent) { FactoryGirl.create(:web_conference_invitation, :sent => true, :ready => true) }
       let!(:invitation_not_sent) { FactoryGirl.create(:web_conference_invitation, :sent => false, :ready => true) }
 
       before(:each) { worker.perform }
 
-      it { expect(InvitationSenderWorker).to have_queue_size_of(1) }
-      it { expect(InvitationSenderWorker).to have_queued(invitation_not_sent.id) }
-      it { expect(InvitationSenderWorker).not_to have_queued(invitation_sent.id) }
+      it { expect(queue).to have_queue_size_of(1) }
+      it { expect(queue).to have_queued(params, invitation_not_sent.id) }
+      it { expect(queue).not_to have_queued(params, invitation_sent.id) }
     end
 
     # describe "saves in the invitation the return if Invitation#send_invitation" do

--- a/spec/workers/join_request_invite_sender_worker_spec.rb
+++ b/spec/workers/join_request_invite_sender_worker_spec.rb
@@ -10,10 +10,6 @@ describe JoinRequestInviteSenderWorker, type: :worker do
   let(:worker) { JoinRequestInviteSenderWorker }
   let(:space) { FactoryGirl.create(:space) }
 
-  it "uses the queue :join_requests" do
-    worker.instance_variable_get(:@queue).should eql(:join_requests)
-  end
-
   describe "#perform" do
 
     context "sends the invitation email" do

--- a/spec/workers/join_request_sender_worker_spec.rb
+++ b/spec/workers/join_request_sender_worker_spec.rb
@@ -10,10 +10,6 @@ describe JoinRequestSenderWorker, type: :worker do
   let(:worker) { JoinRequestSenderWorker }
   let(:space) { FactoryGirl.create(:space) }
 
-  it "uses the queue :join_requests" do
-    worker.instance_variable_get(:@queue).should eql(:join_requests)
-  end
-
   describe "#perform" do
     let(:join_request) { FactoryGirl.create(:space_join_request, group: space) }
     let(:activity) { join_request.new_activity }

--- a/spec/workers/join_requests_worker_spec.rb
+++ b/spec/workers/join_requests_worker_spec.rb
@@ -8,11 +8,14 @@ require 'spec_helper'
 
 describe JoinRequestsWorker, type: :worker do
   let(:worker) { JoinRequestsWorker }
+  let(:senderInv) { JoinRequestInviteSenderWorker }
+  let(:senderS) { JoinRequestSenderWorker }
+  let(:senderProc) { ProcessedJoinRequestSenderWorker }
   let(:space) { FactoryGirl.create(:space) }
-
-  it "uses the queue :join_requests" do
-    worker.instance_variable_get(:@queue).should eql(:join_requests)
-  end
+  let(:queue) { Queue::High }
+  let(:paramsInv) {{"method"=>:perform, "class"=>senderInv.to_s}}
+  let(:paramsS) {{"method"=>:perform, "class"=>senderS.to_s}}
+  let(:paramsProc) {{"method"=>:perform, "class"=>senderProc.to_s}}
 
   describe "#perform" do
 
@@ -32,10 +35,10 @@ describe JoinRequestsWorker, type: :worker do
       }
 
       before(:each) { worker.perform }
-      it { expect(JoinRequestInviteSenderWorker).to have_queue_size_of(2) }
-      it { expect(JoinRequestInviteSenderWorker).to have_queued(@activity[0].id) }
-      it { expect(JoinRequestInviteSenderWorker).to have_queued(@activity[1].id) }
-      it { expect(JoinRequestInviteSenderWorker).not_to have_queued(@activity[2].id) }
+      it { expect(queue).to have_queue_size_of(2) }
+      it { expect(queue).to have_queued(paramsInv, @activity[0].id) }
+      it { expect(queue).to have_queued(paramsInv, @activity[1].id) }
+      it { expect(queue).not_to have_queued(paramsInv, @activity[2].id) }
     end
 
     context "enqueues all unnotified requests" do
@@ -54,10 +57,10 @@ describe JoinRequestsWorker, type: :worker do
       }
 
       before(:each) { worker.perform }
-      it { expect(JoinRequestSenderWorker).to have_queue_size_of(2) }
-      it { expect(JoinRequestSenderWorker).to have_queued(@activity[0].id) }
-      it { expect(JoinRequestSenderWorker).to have_queued(@activity[1].id) }
-      it { expect(JoinRequestSenderWorker).not_to have_queued(@activity[2].id) }
+      it { expect(queue).to have_queue_size_of(2) }
+      it { expect(queue).to have_queued(paramsS, @activity[0].id) }
+      it { expect(queue).to have_queued(paramsS, @activity[1].id) }
+      it { expect(queue).not_to have_queued(paramsS, @activity[2].id) }
     end
 
     context "for unnotified processed requests" do
@@ -78,10 +81,10 @@ describe JoinRequestsWorker, type: :worker do
         }
 
         before(:each) { worker.perform }
-        it { expect(ProcessedJoinRequestSenderWorker).to have_queue_size_of(2) }
-        it { expect(ProcessedJoinRequestSenderWorker).to have_queued(@activity1.id) }
-        it { expect(ProcessedJoinRequestSenderWorker).to have_queued(@activity2.id) }
-        it { expect(ProcessedJoinRequestSenderWorker).not_to have_queued(@activity3.id) }
+        it { expect(queue).to have_queue_size_of(2) }
+        it { expect(queue).to have_queued(paramsProc, @activity1.id) }
+        it { expect(queue).to have_queued(paramsProc, @activity2.id) }
+        it { expect(queue).not_to have_queued(paramsProc, @activity3.id) }
       end
 
       context "ignores requests declined by admins" do
@@ -101,8 +104,8 @@ describe JoinRequestsWorker, type: :worker do
         }
 
         before(:each) { worker.perform }
-        it { expect(ProcessedJoinRequestSenderWorker).to have_queue_size_of(1) }
-        it { expect(ProcessedJoinRequestSenderWorker).to have_queued(@activity2.id) }
+        it { expect(queue).to have_queue_size_of(1) }
+        it { expect(queue).to have_queued(paramsProc, @activity2.id) }
       end
 
       #
@@ -145,10 +148,10 @@ describe JoinRequestsWorker, type: :worker do
         }
 
         before(:each) { worker.perform }
-        it { expect(ProcessedJoinRequestSenderWorker).to have_queue_size_of(3) }
-        it { expect(ProcessedJoinRequestSenderWorker).to have_queued(@activity1.id) }
-        it { expect(ProcessedJoinRequestSenderWorker).to have_queued(@activity2.id) }
-        it { expect(ProcessedJoinRequestSenderWorker).to have_queued(@activity3.id) }
+        it { expect(queue).to have_queue_size_of(3) }
+        it { expect(queue).to have_queued(paramsProc, @activity1.id) }
+        it { expect(queue).to have_queued(paramsProc, @activity2.id) }
+        it { expect(queue).to have_queued(paramsProc, @activity3.id) }
       end
     end
   end

--- a/spec/workers/participant_confirmations_sender_worker_spec.rb
+++ b/spec/workers/participant_confirmations_sender_worker_spec.rb
@@ -9,9 +9,6 @@ require 'spec_helper'
 describe ParticipantConfirmationsSenderWorker, type: :worker do
   let(:worker) { ParticipantConfirmationsSenderWorker }
 
-  it "uses the queue :participant_confirmations" do
-    worker.instance_variable_get(:@queue).should eql(:participant_confirmations)
-  end
 
   describe "#perform" do
     let(:pc1) { FactoryGirl.create(:participant, email: 'abc@def.cam', owner: nil).participant_confirmation }

--- a/spec/workers/participant_confirmations_worker_spec.rb
+++ b/spec/workers/participant_confirmations_worker_spec.rb
@@ -8,10 +8,9 @@ require 'spec_helper'
 
 describe ParticipantConfirmationsWorker, type: :worker do
   let(:worker) { ParticipantConfirmationsWorker }
-
-  it "uses the queue :participant_confirmations" do
-    worker.instance_variable_get(:@queue).should eql(:participant_confirmations)
-  end
+  let(:sender) { ParticipantConfirmationsSenderWorker }
+  let(:queue) { Queue::High }
+  let(:params) {{"method"=>:perform, "class"=>sender.to_s}}
 
   describe "#perform" do
     before { ParticipantConfirmation.delete_all }
@@ -23,11 +22,11 @@ describe ParticipantConfirmationsWorker, type: :worker do
       let!(:pc4) { FactoryGirl.create(:participant_confirmation, email_sent_at: Time.now) }
 
       before(:each) { worker.perform }
-      it { expect(ParticipantConfirmationsSenderWorker).to have_queue_size_of(2) }
-      it { expect(ParticipantConfirmationsSenderWorker).to have_queued(pc1.id) }
-      it { expect(ParticipantConfirmationsSenderWorker).to have_queued(pc3.id) }
-      it { expect(ParticipantConfirmationsSenderWorker).not_to have_queued(pc2.id) }
-      it { expect(ParticipantConfirmationsSenderWorker).not_to have_queued(pc4.id) }
+      it { expect(queue).to have_queue_size_of(2) }
+      it { expect(queue).to have_queued(params, pc1.id) }
+      it { expect(queue).to have_queued(params, pc3.id) }
+      it { expect(queue).not_to have_queued(params, pc2.id) }
+      it { expect(queue).not_to have_queued(params, pc4.id) }
     end
 
   end

--- a/spec/workers/processed_join_request_sender_worker_spec.rb
+++ b/spec/workers/processed_join_request_sender_worker_spec.rb
@@ -17,10 +17,6 @@ describe ProcessedJoinRequestSenderWorker, type: :worker do
     space.add_member!(admin2, 'Admin')
   }
 
-  it "uses the queue :join_requests" do
-    worker.instance_variable_get(:@queue).should eql(:join_requests)
-  end
-
   describe "#perform" do
     context "for a request" do
       let(:join_request) { FactoryGirl.create(:space_join_request, group: space) }

--- a/spec/workers/space_approved_sender_worker_spec.rb
+++ b/spec/workers/space_approved_sender_worker_spec.rb
@@ -14,10 +14,6 @@ describe SpaceApprovedSenderWorker, type: :worker do
     Site.current.update_attributes(require_space_approval: true)
   }
 
-  it "uses the queue :space_notifications" do
-    worker.instance_variable_get(:@queue).should eql(:space_notifications)
-  end
-
   describe "#perform" do
     let(:user) { FactoryGirl.create(:user) }
     let(:space) { FactoryGirl.create(:space, approved: false) }

--- a/spec/workers/space_needs_approval_sender_worker_spec.rb
+++ b/spec/workers/space_needs_approval_sender_worker_spec.rb
@@ -13,10 +13,6 @@ describe SpaceNeedsApprovalSenderWorker, type: :worker do
     Site.current.update_attributes(require_space_approval: true)
   }
 
-  it "uses the queue :space_notifications" do
-    worker.instance_variable_get(:@queue).should eql(:space_notifications)
-  end
-
   describe "#perform" do
     let(:user) { FactoryGirl.create(:user) }
     let(:space) { FactoryGirl.create(:space) }

--- a/spec/workers/space_notifications_worker_spec.rb
+++ b/spec/workers/space_notifications_worker_spec.rb
@@ -8,10 +8,11 @@ require 'spec_helper'
 
 describe SpaceNotificationsWorker, type: :worker do
   let(:worker) { SpaceNotificationsWorker }
-
-  it "uses the queue :space_notifications" do
-    worker.instance_variable_get(:@queue).should eql(:space_notifications)
-  end
+  let(:senderNA) { SpaceNeedsApprovalSenderWorker }
+  let(:senderA) { SpaceApprovedSenderWorker}
+  let(:queue) { Queue::High }
+  let(:paramsNA) {{"method"=>:perform, "class"=>senderNA.to_s}}
+  let(:paramsA) {{"method"=>:perform, "class"=>senderA.to_s}}
 
   describe "#perform" do
 
@@ -36,8 +37,8 @@ describe SpaceNotificationsWorker, type: :worker do
             worker.perform
           }
 
-          it { expect(SpaceNeedsApprovalSenderWorker).to have_queue_size_of(1) }
-          it { expect(SpaceNeedsApprovalSenderWorker).to have_queued(activity.id, admin_ids) }
+          it { expect(queue).to have_queue_size_of(1) }
+          it { expect(queue).to have_queued(paramsNA, activity.id, admin_ids) }
         end
 
         context "ignores space not approved but that already had their notification sent" do
@@ -56,7 +57,7 @@ describe SpaceNotificationsWorker, type: :worker do
           }
           before(:each) { worker.perform }
 
-          it { expect(SpaceNeedsApprovalSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
 
         context "ignores spaces that were already approved" do
@@ -72,7 +73,7 @@ describe SpaceNotificationsWorker, type: :worker do
             worker.perform
           }
 
-          it { expect(SpaceNeedsApprovalSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
 
         context "when the target space cannot be found" do
@@ -88,7 +89,7 @@ describe SpaceNotificationsWorker, type: :worker do
             worker.perform
           }
 
-          it { expect(SpaceNeedsApprovalSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
       end
 
@@ -113,9 +114,9 @@ describe SpaceNotificationsWorker, type: :worker do
             worker.perform
           }
 
-          it { expect(SpaceApprovedSenderWorker).to have_queue_size_of_at_least(2) }
-          it { expect(SpaceApprovedSenderWorker).to have_queued(activity1.id) }
-          it { expect(SpaceApprovedSenderWorker).to have_queued(activity2.id) }
+          it { expect(queue).to have_queue_size_of_at_least(2) }
+          it { expect(queue).to have_queued(paramsA, activity1.id) }
+          it { expect(queue).to have_queued(paramsA, activity2.id) }
         end
 
         context "ignores spaces that were not approved yet" do
@@ -128,7 +129,7 @@ describe SpaceNotificationsWorker, type: :worker do
             worker.perform
           }
 
-          it { expect(SpaceApprovedSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
 
       end
@@ -152,7 +153,7 @@ describe SpaceNotificationsWorker, type: :worker do
           worker.perform
         }
 
-        it { expect(SpaceNeedsApprovalSenderWorker).to have_queue_size_of(0) }
+        it { expect(queue).to have_queue_size_of(0) }
       end
     end
 

--- a/spec/workers/user_approved_sender_worker_spec.rb
+++ b/spec/workers/user_approved_sender_worker_spec.rb
@@ -13,10 +13,6 @@ describe UserApprovedSenderWorker, type: :worker do
     Site.current.update_attributes(require_registration_approval: true)
   }
 
-  it "uses the queue :user_notifications" do
-    worker.instance_variable_get(:@queue).should eql(:user_notifications)
-  end
-
   describe "#perform" do
     let(:user) { FactoryGirl.create(:user, approved: false) }
     let(:activity) { RecentActivity.last }

--- a/spec/workers/user_needs_approval_sender_worker_spec.rb
+++ b/spec/workers/user_needs_approval_sender_worker_spec.rb
@@ -13,10 +13,6 @@ describe UserNeedsApprovalSenderWorker, type: :worker do
     Site.current.update_attributes(require_registration_approval: true)
   }
 
-  it "uses the queue :user_notifications" do
-    worker.instance_variable_get(:@queue).should eql(:user_notifications)
-  end
-
   describe "#perform" do
     let(:user) { FactoryGirl.create(:user) }
     let(:activity) { RecentActivity.where(trackable_type: 'User', key: 'user.created',

--- a/spec/workers/user_notifications_worker_spec.rb
+++ b/spec/workers/user_notifications_worker_spec.rb
@@ -8,10 +8,15 @@ require 'spec_helper'
 
 describe UserNotificationsWorker, type: :worker do
   let(:worker) { UserNotificationsWorker }
-
-  it "uses the queue :user_notifications" do
-    worker.instance_variable_get(:@queue).should eql(:user_notifications)
-  end
+  let(:senderRBA) { UserRegisteredByAdminSenderWorker }
+  let(:senderNA) { UserNeedsApprovalSenderWorker }
+  let(:senderA) { UserApprovedSenderWorker }
+  let(:senderR) { UserRegisteredSenderWorker }
+  let(:queue) { Queue::High }
+  let(:paramsRBA) {{"method"=>:perform, "class"=>senderRBA.to_s}}
+  let(:paramsNA) {{"method"=>:perform, "class"=>senderNA.to_s}}
+  let(:paramsA) {{"method"=>:perform, "class"=>senderA.to_s}}
+  let(:paramsR) {{"method"=>:perform, "class"=>senderR.to_s}}
 
   describe "#perform" do
 
@@ -26,8 +31,8 @@ describe UserNotificationsWorker, type: :worker do
 
         before(:each) { worker.perform }
 
-          it { expect(UserRegisteredByAdminSenderWorker).to have_queue_size_of(1) }
-          it { expect(UserRegisteredByAdminSenderWorker).to have_queued(activity.id) }
+          it { expect(queue).to have_queue_size_of(1) }
+          it { expect(queue).to have_queued(paramsRBA, activity.id) }
       end
     end
 
@@ -50,9 +55,9 @@ describe UserNotificationsWorker, type: :worker do
 
           before(:each) { worker.perform }
 
-          it { expect(UserNeedsApprovalSenderWorker).to have_queue_size_of(2) }
-          it { expect(UserNeedsApprovalSenderWorker).to have_queued(user1.id, admin_ids) }
-          it { expect(UserNeedsApprovalSenderWorker).to have_queued(user2.id, admin_ids) }
+          it { expect(queue).to have_queue_size_of(2) }
+          it { expect(queue).to have_queued(paramsNA, user1.id, admin_ids) }
+          it { expect(queue).to have_queued(paramsNA, user2.id, admin_ids) }
         end
 
         context "ignores users not approved but that already had their notification sent" do
@@ -67,7 +72,7 @@ describe UserNotificationsWorker, type: :worker do
           }
           before(:each) { worker.perform }
 
-          it { expect(UserNeedsApprovalSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
 
         context "ignores users that were already approved" do
@@ -77,7 +82,7 @@ describe UserNotificationsWorker, type: :worker do
 
           before(:each) { worker.perform }
 
-          it { expect(UserNeedsApprovalSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
 
         context "when there are no recipients" do
@@ -85,7 +90,7 @@ describe UserNotificationsWorker, type: :worker do
 
           before(:each) { worker.perform }
 
-          it { expect(UserNeedsApprovalSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
 
         context "when the target user cannot be found" do
@@ -98,7 +103,7 @@ describe UserNotificationsWorker, type: :worker do
             worker.perform
           }
 
-          it { expect(UserNeedsApprovalSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
       end
 
@@ -120,9 +125,9 @@ describe UserNotificationsWorker, type: :worker do
             worker.perform
           }
 
-          it { expect(UserApprovedSenderWorker).to have_queue_size_of_at_least(2) }
-          it { expect(UserApprovedSenderWorker).to have_queued(activity1.id) }
-          it { expect(UserApprovedSenderWorker).to have_queued(activity2.id) }
+          it { expect(queue).to have_queue_size_of_at_least(2) }
+          it { expect(queue).to have_queued(paramsA, activity1.id) }
+          it { expect(queue).to have_queued(paramsA, activity2.id) }
         end
 
         context "ignores users that were not approved yet" do
@@ -131,7 +136,7 @@ describe UserNotificationsWorker, type: :worker do
 
           before(:each) { worker.perform }
 
-          it { expect(UserApprovedSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
 
         context "ignores users that already received the notification" do
@@ -140,7 +145,7 @@ describe UserNotificationsWorker, type: :worker do
 
           before(:each) { worker.perform }
 
-          it { expect(UserApprovedSenderWorker).to have_queue_size_of(0) }
+          it { expect(queue).to have_queue_size_of(0) }
         end
 
       end
@@ -159,7 +164,7 @@ describe UserNotificationsWorker, type: :worker do
 
         before(:each) { worker.perform }
 
-        it { expect(UserNeedsApprovalSenderWorker).to have_queue_size_of(0) }
+        it { expect(queue).to have_queue_size_of(0) }
         context "should generate the activities anyway" do
           it { RecentActivity.where(trackable: user1, key: 'user.created').first.should_not be_nil }
           it { RecentActivity.where(trackable_id: user2, key: 'user.created').first.should_not be_nil }
@@ -172,7 +177,7 @@ describe UserNotificationsWorker, type: :worker do
 
         before(:each) { worker.perform }
 
-        it { expect(UserApprovedSenderWorker).to have_queue_size_of(0) }
+        it { expect(queue).to have_queue_size_of(0) }
       end
     end
 
@@ -188,8 +193,8 @@ describe UserNotificationsWorker, type: :worker do
       context "#perform sends the right mails and updates the activity" do
         before(:each) { worker.perform }
 
-        it { expect(UserRegisteredSenderWorker).to have_queue_size_of(1) }
-        it { expect(UserRegisteredSenderWorker).to have_queued(activity.id) }
+        it { expect(queue).to have_queue_size_of(1) }
+        it { expect(queue).to have_queued(paramsR, activity.id) }
       end
     end
 

--- a/spec/workers/user_registered_by_admin_sender_worker_spec.rb
+++ b/spec/workers/user_registered_by_admin_sender_worker_spec.rb
@@ -9,10 +9,6 @@ require 'spec_helper'
 describe UserRegisteredByAdminSenderWorker, type: :worker do
   let(:worker) { UserRegisteredByAdminSenderWorker }
 
-  it "uses the queue :user_notifications" do
-    worker.instance_variable_get(:@queue).should eql(:user_notifications)
-  end
-
   describe "#perform" do
     let(:user) { FactoryGirl.create(:user) }
 

--- a/spec/workers/user_registered_sender_worker_spec.rb
+++ b/spec/workers/user_registered_sender_worker_spec.rb
@@ -9,10 +9,6 @@ require 'spec_helper'
 describe UserRegisteredSenderWorker, type: :worker do
   let(:worker) { UserRegisteredSenderWorker }
 
-  it "uses the queue :user_notifications" do
-    worker.instance_variable_get(:@queue).should eql(:user_notifications)
-  end
-
   describe "#perform" do
     let(:user) { FactoryGirl.create(:user) }
 


### PR DESCRIPTION
We can now decide the priorities of each type by changing the queue that the jobs are enqueued to
We now have to set QUEUE="high, ...,  normal, ..., low" in order for Resque to respect the priorities when starting a worker
Added the QUEUE priority order to the script that starts the workers when run for all queues

Closes #787 feature implementation 