### PR TITLE
Implemented the first suggested Solution

### DIFF
--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -72,6 +72,10 @@ class Space < ActiveRecord::Base
     Site.current.require_space_approval?
   end
 
+  def is_approved?
+    require_approval? || ( !require_approval? && !approved? )
+  end
+
   validates :description, :presence => true
 
   validates :name, :presence => true,

--- a/app/views/layouts/_spaces_page_title.html.haml
+++ b/app/views/layouts/_spaces_page_title.html.haml
@@ -23,7 +23,7 @@
       %span.user-is-member
         = icon_is_member
         = t(".is_member")
-    - if current_site.require_space_approval? && !@space.approved?
+    - if !@space.approved?
       .resource-waiting-tooltip
         = icon_waiting_moderation
         = t("_other.not_approved.text")

--- a/app/views/manage/_disabled_space.html.haml
+++ b/app/views/manage/_disabled_space.html.haml
@@ -1,4 +1,4 @@
-.thread.thread-space.space-wrapper.space-simple.space-disabled{:class => "#{cycle("thread-even" , "thread-odd")}"}
+.thread.thread-space.space-wrapper.space-simple.space-disabled{:class => "#{cycle("thread-even" , "thread-odd")}", :id => "space-#{space.permalink}"}
   .logo-in-thread
     = raw logo_image(space, :size => '84x64', :title => space.name, :class => 'logo logo-space')
 

--- a/app/views/manage/_enabled_space.html.haml
+++ b/app/views/manage/_enabled_space.html.haml
@@ -1,4 +1,4 @@
-.thread.thread-space.space-wrapper.space-simple{:class => "#{cycle("thread-even" , "thread-odd")}"}
+.thread.thread-space.space-wrapper.space-simple{:class => "#{cycle("thread-even" , "thread-odd")}", :id => "space-#{space.permalink}"}
   .logo-in-thread
     = link_logo_image(space, options_for_tooltip(sanitize(space.name), :size => '84x64', :class => "logo logo-space"))
 
@@ -6,7 +6,7 @@
     = link_to (edit_space_path(space)) do
       = icon_edit(:alt => t('.edit'), :title => t('.edit'))
 
-    - if current_site.require_space_approval?
+    - if space.is_approved?
       = approval_links :space, space
 
     = link_to disable_space_path(space), :data => { :confirm => t('.disable_confirm') }, :method => :delete do
@@ -20,7 +20,7 @@
   %span.space-description
     = sanitize(first_words(space.description, 100))
 
-    - if current_site.require_space_approval? && !space.approved?
+    - if !space.approved?
       .resource-waiting-moderation-tooltip
         = icon_waiting_moderation
         = t("_other.not_approved.text")

--- a/spec/features/manage/admin_manages_spaces_spec.rb
+++ b/spec/features/manage/admin_manages_spaces_spec.rb
@@ -1,0 +1,196 @@
+# This file is part of Mconf-Web, a web application that provides access
+# to the Mconf webconferencing system. Copyright (C) 2010-2015 Mconf.
+#
+# This file is licensed under the Affero General Public License version
+# 3 or later. See the LICENSE file.
+
+require 'spec_helper'
+require 'support/feature_helpers'
+
+describe 'Admin manages spaces' do
+  subject { page }
+
+  context 'with require registration approval disabled' do
+
+    let(:admin) { User.first } # admin is already created
+    before {
+      Site.current.update_attributes(require_registration_approval: true)
+
+      login_as(admin, :scope => :user)
+      @approved_space = FactoryGirl.create(:space, :name => 'Approved', :approved => true, :description => "This space is approved")
+      @not_approved_space = FactoryGirl.create(:space, :name => 'Not Approved', :approved => false, :description => "This space is not approved")
+      @enabled_space = FactoryGirl.create(:space, :name => 'Enabled', :disabled => false, :description => "This space is enabled")
+      @disabled_space =FactoryGirl.create(:space, :name => 'Disabled', :disabled => true, :description => "This space is disabled")
+      @not_approved_space.disapprove!
+    }
+
+    context 'listing spaces in management screen' do
+      before { visit manage_spaces_path }
+
+      it { should have_css '.space-simple', :count => 4 }
+      it { should have_css '.icon-mconf-delete', :count => 4 }
+
+      it { should have_css '.space-disabled', :count => 1 }
+      it { should have_css '.icon-mconf-enable', :count => 1 }
+
+      it { should have_css '.icon-mconf-edit', :count => 3 }
+      it { should have_css '.icon-mconf-disable', :count => 3 }
+
+      it { should have_content @approved_space.name }
+      it { should have_content @approved_space.description }
+      it { should have_content @not_approved_space.name }
+      it { should have_content @not_approved_space.description }
+      it { should have_content @enabled_space.name }
+      it { should have_content @enabled_space.description }
+      it { should have_content @disabled_space.name }
+      
+      context 'elements for an approved space' do
+        let(:space) { @approved_space }
+        subject { page.find("#space-#{space.permalink}") }
+
+        it { should have_css 'img.logo-space' }
+        it { should have_css '.management-links' }
+        it { should_not have_content t('._other.not_approved.text') }
+        it { should have_link_to_edit_space(space) }
+        it { should have_link_to_destroy_space(space) }
+        it { should have_link_to_disable_space(space) }
+        it { should_not have_link_to_approve_space(space) }
+        it { should_not have_link_to_disapprove_space(space) }
+      end
+
+      context 'elements for a not approved space' do
+        let(:space) { @not_approved_space }
+        subject { page.find("#space-#{space.permalink}") }
+
+        it { should have_css 'img.logo-space' }
+        it { should have_css '.management-links' }
+        it { should have_content t('._other.not_approved.text') }
+        it { should have_link_to_edit_space(space) }
+        it { should have_link_to_destroy_space(space) }
+        it { should have_link_to_disable_space(space) }
+        it { should have_link_to_approve_space(space) }
+        it { should_not have_link_to_disapprove_space(space) }
+      end
+
+      context 'elements for a disabled space' do
+        let(:space) { @disabled_space }
+        subject { page.find("#space-#{space.permalink}") }
+
+        it { should have_css 'img.logo-space' }
+        it { should have_css '.management-links' }
+        it { should_not have_css '.icon-mconf-edit' }
+        it { should_not have_content t('._other.not_approved.text') }
+        it { should_not have_link_to_edit_space(space) }
+        it { should have_link_to_destroy_space(space) }
+        it { should have_link_to_enable_space(space) }
+        it { should_not have_link_to_disable_space(space) }
+        it { should_not have_link_to_approve_space(space) }
+        it { should_not have_link_to_disapprove_space(space) }
+      end
+
+      context 'elements for an enabled space' do
+        let(:space) { @enabled_space }
+        subject { page.find("#space-#{space.permalink}") }
+
+        it { should have_css 'img.logo-space' }
+        it { should have_css '.management-links' }
+        it { should_not have_content t('._other.not_approved.text') }
+        it { should have_link_to_edit_space(space) }
+        it { should have_link_to_destroy_space(space) }
+        it { should have_link_to_disable_space(space) }
+        it { should_not have_link_to_approve_space(space) }
+        it { should_not have_link_to_disapprove_space(space) }
+      end
+    end
+
+    context 'with require registration approval enabled' do
+      before {
+        Site.current.update_attributes(:require_space_approval => true)
+        visit manage_spaces_path
+      }
+
+      context 'elements for an approved space' do
+        let(:space) { @approved_space }
+        subject { page.find("#space-#{space.permalink}") }
+
+        it { should have_css 'img.logo-space' }
+        it { should have_css '.management-links' }
+        it { should_not have_content t('._other.not_approved.text') }
+        it { should have_link_to_edit_space(space) }
+        it { should have_link_to_destroy_space(space) }
+        it { should have_link_to_disable_space(space) }
+        it { should_not have_link_to_approve_space(space) }
+        it { should have_link_to_disapprove_space(space) }
+      end
+
+      context 'elements for a not approved space' do
+        let(:space) { @not_approved_space }
+        subject { page.find("#space-#{space.permalink}") }
+
+        it { should have_css 'img.logo-space' }
+        it { should have_css '.management-links' }
+        it { should have_content t('._other.not_approved.text') }
+        it { should have_link_to_edit_space(space) }
+        it { should have_link_to_destroy_space(space) }
+        it { should have_link_to_disable_space(space) }
+        it { should_not have_link_to_disapprove_space(space) }
+        it { should have_link_to_approve_space(space) }
+      end
+
+      context 'elements for a disabled space' do
+        let(:space) { @disabled_space }
+        subject { page.find("#space-#{space.permalink}") }
+
+        it { should have_css 'img.logo-space' }
+        it { should have_css '.management-links' }
+        it { should_not have_css '.icon-mconf-edit' }
+        it { should_not have_content t('._other.not_approved.text') }
+        it { should_not have_link_to_edit_space(space) }
+        it { should have_link_to_destroy_space(space) }
+        it { should have_link_to_enable_space(space) }
+        it { should_not have_link_to_disable_space(space) }
+        it { should_not have_link_to_approve_space(space) }
+        it { should_not have_link_to_disapprove_space(space) }
+      end
+
+      context 'elements for an enabled space' do
+        let(:space) { @enabled_space }
+        subject { page.find("#space-#{space.permalink}") }
+
+        it { should have_css 'img.logo-space' }
+        it { should have_css '.management-links' }
+        it { should_not have_content t('._other.not_approved.text') }
+        it { should have_link_to_edit_space(space) }
+        it { should have_link_to_destroy_space(space) }
+        it { should have_link_to_disable_space(space) }
+        it { should_not have_link_to_approve_space(space) }
+        it { should have_link_to_disapprove_space(space) }
+      end
+    end
+
+  end
+end
+
+def have_link_to_edit_space(space)
+  have_link '', :href => edit_space_path(space)
+end
+
+def have_link_to_destroy_space(space)
+  have_css("a[href='#{space_path(space)}'][data-method='delete']")
+end
+
+def have_link_to_disable_space(space)
+  have_css("a[href='#{disable_space_path(space)}'][data-method='delete']")
+end
+
+def have_link_to_enable_space(space)
+  have_link '', :href => enable_space_path(space)
+end
+
+def have_link_to_disapprove_space(space)
+  have_link '', :href => disapprove_space_path(space)
+end
+
+def have_link_to_approve_space(space)
+  have_link '', :href => approve_space_path(space)
+end


### PR DESCRIPTION
Now there will always be a button to approve spaces even if the Site does not require space approval
Every other view will show warnings about the "not approved" state of the space, consistently with the approved flag

Resolves #879 

The comment about Mconf-RNP similar scenario will be validated once this implementation is merged to the RNP fork.
