### PR TITLE
Separate site reply email #894

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -46,7 +46,7 @@ class SitesController < ApplicationController
      :analytics_code, :shib_enabled, :shib_email_field, :shib_name_field, :shib_principal_name_field, :shib_login_field,
      :shib_env_variables, :shib_always_new_account, :ldap_enabled, :ldap_host, :ldap_port, :ldap_user, :ldap_user_password,
      :ldap_user_treebase, :ldap_username_field, :ldap_email_field, :ldap_name_field, :ldap_filter, :smtp_login, :smtp_password,
-     :smtp_sender, :smtp_domain, :smtp_server, :smtp_port, :smtp_use_tls, :smtp_auto_tls, :smtp_auth_type, :exception_notifications,
+     :smtp_sender, :smtp_receiver, :smtp_domain, :smtp_server, :smtp_port, :smtp_use_tls, :smtp_auto_tls, :smtp_auth_type, :exception_notifications,
      :exception_notifications_email, :exception_notifications_prefix, :presence_domain, :xmpp_server, :external_help,
      :registration_enabled, :require_registration_approval, :local_auth_enabled, :events_enabled, :room_dial_number_pattern,
      :shib_update_users, :require_space_approval, :forbid_user_space_creation, :max_upload_size, :use_gravatar,

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -14,7 +14,7 @@ class ApplicationMailer < BaseMailer
       subject = "#{I18n.t("application_mailer.feedback_email.subject")}: #{subject}"
       @text = body
       @email = email
-      create_email(Site.current.smtp_sender, email, subject)
+      create_email(Site.current.smtp_receiver, email, subject)
     end
   end
 end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -44,6 +44,15 @@ class Site < ActiveRecord::Base
     Mconf::Filesize.human_file_size(self.max_upload_size)
   end
 
+  def smtp_receiver
+    if read_attribute(:smtp_receiver).blank?
+      smtp_to = read_attribute(:smtp_sender)
+    else
+      smtp_to = read_attribute(:smtp_receiver)
+    end
+    smtp_to
+  end
+
   private
 
   def validate_and_adjust_max_upload_size

--- a/app/views/sites/edit.html.haml
+++ b/app/views/sites/edit.html.haml
@@ -38,6 +38,7 @@
     = f.input :smtp_login
     = f.input :smtp_password, :as => :showable_password
     = f.input :smtp_sender
+    = f.input :smtp_receiver
     = f.input :smtp_domain
     = f.input :smtp_server
     = f.input :smtp_port

--- a/app/views/sites/show.html.haml
+++ b/app/views/sites/show.html.haml
@@ -34,6 +34,7 @@
     = f.input :smtp_login, :disabled => true
     = f.input :smtp_password, :as => :showable_password, :disabled => true
     = f.input :smtp_sender, :disabled => true
+    = f.input :smtp_receiver, :disabled => true
     = f.input :smtp_domain, :disabled => true
     = f.input :smtp_server, :disabled => true
     = f.input :smtp_port, :disabled => true

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -192,6 +192,7 @@ en:
         smtp_password: "SMTP password"
         smtp_port: "SMTP port"
         smtp_sender: "SMTP sender"
+        smtp_receiver: "SMTP receiver"
         smtp_server: "SMTP server"
         smtp_use_tls: "Use TLS in SMTP"
         ssl: "SSL"

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -194,6 +194,7 @@ pt-br:
         smtp_password: "Senha SMTP"
         smtp_port: "Porta SMTP"
         smtp_sender: "Remetente SMTP"
+        smtp_sender: "Destinatário SMTP"
         smtp_server: "Servidor SMTP"
         smtp_use_tls: "Usar TLS no STMP"
         ssl: "SSL"

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -194,7 +194,7 @@ pt-br:
         smtp_password: "Senha SMTP"
         smtp_port: "Porta SMTP"
         smtp_sender: "Remetente SMTP"
-        smtp_sender: "Destinatário SMTP"
+        smtp_receiver: "Destinatário SMTP"
         smtp_server: "Servidor SMTP"
         smtp_use_tls: "Usar TLS no STMP"
         ssl: "SSL"

--- a/db/migrate/20161108173649_add_smtp_receiver_to_sites.rb
+++ b/db/migrate/20161108173649_add_smtp_receiver_to_sites.rb
@@ -1,0 +1,8 @@
+class AddSmtpReceiverToSites < ActiveRecord::Migration
+  def up
+    add_column :sites, :smtp_receiver, :string
+  end
+   def down
+    remove_column :sites, :smtp_receiver
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160926154808) do
+ActiveRecord::Schema.define(version: 20161108173649) do
 
   create_table "activities", force: true do |t|
     t.integer  "trackable_id"
@@ -212,6 +212,7 @@ ActiveRecord::Schema.define(version: 20160926154808) do
     t.boolean  "result",          default: false
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "owner_id"
   end
 
   add_index "invitations", ["target_id", "target_type"], name: "index_invitations_on_target_id_and_target_type", using: :btree
@@ -381,6 +382,7 @@ ActiveRecord::Schema.define(version: 20160926154808) do
     t.string   "max_upload_size",                default: "15000000"
     t.boolean  "shib_update_users",              default: false
     t.boolean  "use_gravatar",                   default: false
+    t.string   "smtp_receiver"
   end
 
   create_table "spaces", force: true do |t|

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -14,7 +14,7 @@ describe ApplicationMailer do
     let(:mail) { ApplicationMailer.feedback_email(user.email, subject, message) }
 
     context "in the standard case" do
-      it("sets 'to'") { mail.to.should eql([Site.current.smtp_sender]) }
+      it("sets 'to'") { mail.to.should eql([Site.current.smtp_receiver]) }
       it("sets 'subject'") {
         text = "[#{Site.current.name}] #{I18n.t('application_mailer.feedback_email.subject')}: #{subject}"
         mail.subject.should eql(text)


### PR DESCRIPTION
Added a smtp_receiver e-mail to get the user feedback
Email is configurable in /site and will use smtp_sender if left blank

Resolves #894 