### PR TITLE
Allow events to have multiple organizers

### DIFF
--- a/app/assets/javascripts/app/application/user_select.js.coffee
+++ b/app/assets/javascripts/app/application/user_select.js.coffee
@@ -1,0 +1,28 @@
+class mconf.UserSelect
+
+  @bind: (id) ->
+    url = '/users/select?limit=10'
+
+    $(id).select2
+      minimumInputLength: 1
+      width: 'resolve'
+      multiple: true
+      formatSearching: -> I18n.t('join_requests.invite.users.searching')
+      formatInputTooShort: -> I18n.t('join_requests.invite.users.hint')
+      formatNoMatches: -> I18n.t('join_requests.invite.users.no_results')
+      tokenSeparators: [",",";"]
+
+      formatSelection: (object, container) ->
+        text = if object.name?
+          object.name
+        else
+          object.text
+        mconf.Base.escapeHTML(text)
+
+      ajax:
+        url: url
+        dataType: "json"
+        data: (term, page) ->
+          q: term # search term
+        results: (data, page) -> # parse the results into the format expected by Select2.
+          results: data

--- a/app/assets/javascripts/app/mweb_events-events/user_permissions.js.coffee
+++ b/app/assets/javascripts/app/mweb_events-events/user_permissions.js.coffee
@@ -1,0 +1,5 @@
+#= require "../application/user_select"
+
+$ ->
+  if isOnPage 'mweb_events-events', 'user_permissions'
+    mconf.UserSelect.bind('#users')

--- a/app/assets/javascripts/app/mweb_events-participants/index.js.coffee
+++ b/app/assets/javascripts/app/mweb_events-participants/index.js.coffee
@@ -1,8 +1,10 @@
 #= require "../mweb_events-events/_invite"
+#= require "../application/user_select"
 
 $ ->
   if isOnPage 'mweb_events-participants', 'index'
 
     # set to rebind the invitation view when the resources are rebound
     mconf.Resources.addToBind ->
+      mconf.UserSelect.bind('#users')
       mconf.MwebEventsEvents.Invitation.bind()

--- a/app/assets/stylesheets/app/mweb_events-events/user_permissions.css.scss
+++ b/app/assets/stylesheets/app/mweb_events-events/user_permissions.css.scss
@@ -1,0 +1,3 @@
+@import "definitions";
+@import "compass/css3";
+@import "app/shared/event_user_permissions";

--- a/app/assets/stylesheets/app/mweb_events-participants/index.css.scss
+++ b/app/assets/stylesheets/app/mweb_events-participants/index.css.scss
@@ -1,5 +1,6 @@
 @import "definitions";
 @import "compass/css3";
+@import "app/shared/event_user_permissions";
 
 body.mweb_events-participants.index {
 

--- a/app/assets/stylesheets/app/shared/_event_user_permissions.css.scss
+++ b/app/assets/stylesheets/app/shared/_event_user_permissions.css.scss
@@ -1,0 +1,25 @@
+#organizer-permission {
+
+  clear: both;
+
+  select {
+    width: auto;
+  }
+
+  form {
+    .input {
+      margin: 0;
+      padding: 0;
+      float: left;
+    }
+
+    .btn {
+      margin: 4px 0 0 5px;
+    }
+  }
+
+  .thread .thread-text {
+    float: right;
+  }
+
+}

--- a/app/assets/stylesheets/mweb_events-events.css
+++ b/app/assets/stylesheets/mweb_events-events.css
@@ -4,4 +4,5 @@
  *= require ./app/mweb_events-events/show
  *= require ./app/mweb_events-events/new
  *= require ./app/mweb_events-events/edit
+ *= require ./app/mweb_events-events/user_permissions
  */

--- a/app/views/mweb_events/events/_organizer_button.html.haml
+++ b/app/views/mweb_events/events/_organizer_button.html.haml
@@ -1,0 +1,5 @@
+- if can?(:user_permissions, @event)
+  %session.event-invite
+    = link_to main_app.user_permissions_event_path(@event), :class => 'open-modal btn btn-info btn-block' do
+      %i.icon.icon-wrench
+      = t('mweb_events.events.user_permissions.manage_organizers')

--- a/app/views/mweb_events/events/_registration.html.haml
+++ b/app/views/mweb_events/events/_registration.html.haml
@@ -25,3 +25,4 @@
         = t('.need_sign_in')
 
 = render 'invite_button'
+= render 'organizer_button'

--- a/app/views/mweb_events/events/user_permissions.html.haml
+++ b/app/views/mweb_events/events/user_permissions.html.haml
@@ -1,0 +1,31 @@
+= render 'title'
+
+#organizer-permission
+
+  .modal-header
+    = modal_close_button
+    %h3= t('.title')
+
+  .modal-body
+    - for permission in @permissions
+      - user = permission.user
+      %div{:class => "thread #{cycle('thread-even','thread-odd')}"}
+        .logo-in-thread
+          = link_logo_image(user, :size => '32', :url => main_app.user_path(user), :title => user.name, :class => "logo logo-user")
+        .thread-content
+          - unless permission.user == current_user
+            .thread-text
+              = simple_form_for :permission, :url => main_app.permission_path(permission), :html => { :method => :delete, class: 'form-inline' } do |f|
+                = f.submit t('destroy'), :class => "btn btn-danger btn-small"
+          .thread-title
+            = link_to sanitize(user.name), main_app.user_path(user)
+            .user-email
+              = "(#{user.username}, #{user.email})"
+
+    #add-organizer
+      %h3= t('.add_organizers')
+      = simple_form_for :permission, :url => main_app.create_permission_event_path(@event), :html => { class: 'form-inline' } do |f|
+        %label= t('.users')
+        = text_field_tag :users, '', autofocus: true, class: 'string'
+
+        = f.submit t('button.send'), :class => "btn btn-small"

--- a/app/views/mweb_events/participants/index.html.haml
+++ b/app/views/mweb_events/participants/index.html.haml
@@ -3,6 +3,7 @@
 = content_for :sidebar do
   = link_to t('.back_to_event'), @event, :class => "btn btn-block"
   = render 'mweb_events/events/invite_button'
+  = render 'mweb_events/events/organizer_button'
 
 %h3= t(".title")
 

--- a/config/locales/en/_mweb_events.yml
+++ b/config/locales/en/_mweb_events.yml
@@ -60,6 +60,14 @@ en:
         private: "Private event"
         public: "Public event"
         starts_at: "Starts at"
+      user_permissions:
+        title: Event organizers
+        users: Users
+        add_organizers: Add more organizers
+        manage_organizers: Manage organizers
+      create_permission:
+        failure: "Failed to add some organizers: %{names}"
+        success: Succesfully added organizers.
     participants:
       index:
         back_to_event: "Go back to the event page"

--- a/config/locales/pt-br/_mweb_events.yml
+++ b/config/locales/pt-br/_mweb_events.yml
@@ -60,6 +60,14 @@ pt-br:
         private: "Evento privado"
         public: "Evento público"
         starts_at: "Inicia em"
+      user_permissions:
+        title: Organizadores do evento
+        users: Usuários
+        add_organizers: Adicionar mais organizadores
+        manage_organizers: Gerenciar organizadores
+      create_permission:
+        failure: "Falha ao adicionar alguns organizadores: %{names}"
+        success: Organizadores adicionados com sucesso.
     participants:
       index:
         back_to_event: "Voltar para a página do evento"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,6 +69,8 @@ Mconf::Application.routes.draw do
       member do
         post :send_invitation, controller: 'mweb_events/events'
         get  :invite, controller: 'mweb_events/events'
+        get :user_permissions, controller: 'mweb_events/events'
+        post :create_permission, controller: 'mweb_events/events'
       end
     end
   end

--- a/db/migrate/20150225222931_migrate_event_organizer_role.rb
+++ b/db/migrate/20150225222931_migrate_event_organizer_role.rb
@@ -1,0 +1,11 @@
+class MigrateEventOrganizerRole < ActiveRecord::Migration
+  def up
+    role = Role.where(stage_type: 'Event', name: 'Organizer').first
+    role.try(:update_attribute, :stage_type, 'MwebEvents::Event')
+  end
+
+  def down
+    role = Role.where(stage_type: 'MwebEvents::Event', name: 'Organizer').first
+    role.try(:update_attribute, :stage_type, 'Event')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141218184717) do
+ActiveRecord::Schema.define(version: 20150225222931) do
 
   create_table "activities", force: true do |t|
     t.integer  "trackable_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -41,7 +41,7 @@ end
 puts "* Create default roles"
 Role.create! :name => 'User', :stage_type => 'Space'
 Role.create! :name => 'Admin', :stage_type => 'Space'
-Role.create! :name => 'Organizer', :stage_type => 'Event'
+Role.create! :name => 'Organizer', :stage_type => 'MwebEvents::Event'
 
 
 puts "* Create the administrator account"

--- a/lib/mweb_events/models/event.rb
+++ b/lib/mweb_events/models/event.rb
@@ -3,8 +3,8 @@ MwebEvents::Event.class_eval do
 
   has_many :permissions, -> { where(:subject_type => 'MwebEvents::Event') }, :foreign_key => "subject_id"
 
-  has_and_belongs_to_many :organizers,
-   -> { Permission.where(:subject_type => 'MwebEvents::Event') }, :join_table => :permissions, :foreign_key => "subject_id"
+  has_and_belongs_to_many :organizers, -> { Permission.where(:subject_type => 'MwebEvents::Event') },
+    :class_name => "User", :join_table => :permissions, :foreign_key => "subject_id"
 
   def self.organizer_role
     Role.where(stage_type: 'MwebEvents::Event', name: 'Organizer').first
@@ -18,7 +18,7 @@ MwebEvents::Event.class_eval do
     create_activity key, :owner => owner, :parameters => { :user_id => user.try(:id), :username => user.try(:name) }
   end
 
-  def add_organizer user
+  def add_organizer! user
     permissions.create(user: user, role: MwebEvents::Event.organizer_role)
   end
 

--- a/lib/mweb_events/models/event.rb
+++ b/lib/mweb_events/models/event.rb
@@ -1,12 +1,25 @@
 MwebEvents::Event.class_eval do
   include PublicActivity::Common
 
+  has_many :permissions, -> { where(:subject_type => 'MwebEvents::Event') }, :foreign_key => "subject_id"
+
+  has_and_belongs_to_many :organizers,
+   -> { Permission.where(:subject_type => 'MwebEvents::Event') }, :join_table => :permissions, :foreign_key => "subject_id"
+
+  def self.organizer_role
+    Role.where(stage_type: 'MwebEvents::Event', name: 'Organizer').first
+  end
+
   def self.host
     Site.current.domain || 'example.com'
   end
 
   def new_activity key, user
     create_activity key, :owner => owner, :parameters => { :user_id => user.try(:id), :username => user.try(:name) }
+  end
+
+  def add_organizer user
+    permissions.create(user: user, role: MwebEvents::Event.organizer_role)
   end
 
   # Temporary while we have no private events

--- a/spec/controllers/permissions_controller_spec.rb
+++ b/spec/controllers/permissions_controller_spec.rb
@@ -44,5 +44,40 @@ describe PermissionsController do
     end
   end
 
-  it "#destroy"
+  describe "#destroy" do
+    let(:user) { FactoryGirl.create(:user) }
+
+    context 'space permission' do
+      let(:permission) { FactoryGirl.create(:space_permission) }
+      let(:referer) { '/' }
+
+      before {
+        request.env['HTTP_REFERER'] = referer
+        permission.subject.add_member!(user, 'Admin')
+        sign_in(user)
+        expect {
+          delete :destroy, id: permission.id
+        }.to change(Permission, :count).by(-1)
+      }
+
+      it { should redirect_to(referer) }
+    end
+
+    context 'event permission' do
+      let(:event) { FactoryGirl.create(:event) }
+      let(:permission) { FactoryGirl.create(:permission, subject: event, role: MwebEvents::Event.organizer_role) }
+      let(:referer) { '/' }
+
+      before {
+        request.env['HTTP_REFERER'] = referer
+        permission.subject.add_organizer!(user)
+        sign_in(user)
+        expect {
+          delete :destroy, id: permission.id
+        }.to change(Permission, :count).by(-1)
+      }
+
+      it { should redirect_to(referer) }
+    end
+  end
 end

--- a/spec/features/events/an_organizer_in_his_event.rb
+++ b/spec/features/events/an_organizer_in_his_event.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+require 'support/feature_helpers'
+
+feature "Visitor in an event page" do
+
+  before(:all) { Site.current.update_attributes(events_enabled: true) }
+
+  shared_examples_for 'it can see event organizer options' do
+    before {
+      login_as(user)
+      visit mweb_events.event_path(event)
+    }
+
+    subject { page }
+    context 'inside event registration area' do
+      it { should have_link(I18n.t('mweb_events.events.registration.invite_button'), :href => invite_event_path(event)) }
+      it { should have_link(I18n.t('mweb_events.events.user_permissions.manage_organizers'), :href => user_permissions_event_path(event)) }
+    end
+
+    context 'in event footer' do
+      subject { page.find('.event-footer') }
+
+      it { should have_link(I18n.t('mweb_events.events.show.manage'), :href => mweb_events.event_participants_path(event)) }
+      it { should have_link(I18n.t('_other.edit'), :href => mweb_events.edit_event_path(event)) }
+    end
+  end
+
+  context 'in a public event owned by him' do
+    let(:event) { FactoryGirl.create(:event, :owner => FactoryGirl.create(:user)) }
+    let(:user) { event.owner }
+
+    it_should_behave_like 'it can see event organizer options'
+  end
+
+  context "in an event where he's an organizer" do
+    let(:event) { FactoryGirl.create(:event, owner: FactoryGirl.create(:user)) }
+    let(:user) { FactoryGirl.create(:user) }
+    before { event.add_organizer!(user) }
+
+    it_should_behave_like 'it can see event organizer options'
+  end
+
+  context "in a space event where he's an organizer" do
+    let(:event) { FactoryGirl.create(:event, owner: FactoryGirl.create(:space)) }
+    let(:user) { FactoryGirl.create(:user) }
+    before { event.add_organizer!(user) }
+
+    it_should_behave_like 'it can see event organizer options'
+  end
+
+  context "in a space event where he's a space admin" do
+    let(:event) { FactoryGirl.create(:event, owner: FactoryGirl.create(:space)) }
+    let(:user) { FactoryGirl.create(:user) }
+    before { event.owner.add_member!(user, 'Admin') }
+
+    it_should_behave_like 'it can see event organizer options'
+  end
+
+end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -81,7 +81,7 @@ describe Permission do
           end
         }
         let(:ability_check) {
-          should_not be_able_to_do_anything_to(target).except([:read, :edit, :update])
+          should_not be_able_to_do_anything_to(target).except([:read, :edit, :update, :destroy])
         }
         it_should_behave_like "for all permission types"
       end


### PR DESCRIPTION
Now events can have multiple organizers instead of having only the creator of the event as organizer.

Resolves #591.