### PR TITLE
Recording permission button user manage #918

### DIFF
--- a/app/assets/stylesheets/app/application/font-awesome.css.scss
+++ b/app/assets/stylesheets/app/application/font-awesome.css.scss
@@ -206,6 +206,14 @@ a .icon-awesome {
   }
 }
 
+.icon-mconf-can-rec {
+  color: $red;
+}
+
+.icon-mconf-cant-rec {
+  color: #CCC;
+}
+
 .icon-mconf-event {}
 .icon-mconf-home {}
 .icon-mconf-logout {}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -403,4 +403,20 @@ class ApplicationController < ActionController::Base
       format.js   { render json: { error: true, message: "You need to sign in or sign up before continuing." }, status: :unauthorized }
     end
   end
+
+  def redirect_to_using_params(options={}, response_status={})
+    unless params[:redir_url].blank?
+      redirect_to params[:redir_url], response_status
+    else
+      redirect_to options, response_status
+    end
+  end
+
+  def redirect_to_params_or_render(action=nil, response_status={})
+    unless params[:redir_url].blank?
+      redirect_to params[:redir_url], response_status
+    else
+      render action, response_status
+    end
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -90,9 +90,10 @@ class UsersController < InheritedResources::Base
       sign_in @user, :bypass => true if current_user == @user
 
       flash = { :success => t("user.updated") }
-      redirect_to params[:return_to] || edit_user_path(@user), :flash => flash
+      redirect_to_using_params params[:return_to] || edit_user_path(@user), :flash => flash
     else
-      render "edit", :layout => 'no_sidebar'
+      flash = { :error => t("user.not_updated") }
+      redirect_to_params_or_render "edit", :layout => 'no_sidebar', :flash => flash
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -93,7 +93,7 @@ class UsersController < InheritedResources::Base
       redirect_to_using_params edit_user_path(@user), :flash => flash
     else
       flash = { :error => t("user.not_updated") }
-      render "edit", layout: 'no_sidebar', flash: flash
+      redirect_to_params_or_render "edit", layout: 'no_sidebar', flash: flash
     end
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -90,10 +90,10 @@ class UsersController < InheritedResources::Base
       sign_in @user, :bypass => true if current_user == @user
 
       flash = { :success => t("user.updated") }
-      redirect_to_using_params params[:return_to] || edit_user_path(@user), :flash => flash
+      redirect_to_using_params edit_user_path(@user), :flash => flash
     else
       flash = { :error => t("user.not_updated") }
-      redirect_to_params_or_render "edit", :layout => 'no_sidebar', :flash => flash
+      render "edit", layout: 'no_sidebar', flash: flash
     end
   end
 

--- a/app/helpers/icons_helper.rb
+++ b/app/helpers/icons_helper.rb
@@ -251,6 +251,14 @@ module IconsHelper
     icon_constructor nil, "icon-awesome icon-remove icon-mconf-participant-not-confirmed", options
   end
 
+  def icon_can_rec(options={})
+    icon_constructor nil, "icon-awesome icon-circle icon-mconf-can-rec", options
+  end
+
+  def icon_cant_rec(options={})
+    icon_constructor nil, "icon-awesome icon-circle icon-mconf-cant-rec", options
+  end
+
   private
 
   # Base method for most of the methods above

--- a/app/views/manage/_enabled_user.html.haml
+++ b/app/views/manage/_enabled_user.html.haml
@@ -13,10 +13,10 @@
 
     - if !user.can_record?
       = link_to user_path(user, user: {can_record: true}, redir_url: manage_users_path(params)), method: :patch do
-        = icon_recording(:alt => t('.allow_record'), :title => t('.allow_record'))
+        = icon_cant_rec(alt: t('.allow_record'), title: t('.allow_record'))
     - else
       = link_to user_path(user, user: {can_record: false}, redir_url: manage_users_path(params)), method: :patch do
-        = icon_error(:alt => t('.disallow_record'), :title => t('.disallow_record'))
+        = icon_can_rec(alt: t('.disallow_record'), title: t('.disallow_record'))
 
     - unless user.superuser  # prevent admins from disabling and disapproving themselves
       - if user.require_approval? || !user.approved?

--- a/app/views/manage/_enabled_user.html.haml
+++ b/app/views/manage/_enabled_user.html.haml
@@ -11,6 +11,13 @@
       = link_to confirm_user_path(user), :data => { :confirm => t('.confirm_confirm') },  :method => :post do
         = icon_confirm_user(:alt => t('.confirm'), :title => t('.confirm'))
 
+    - if !user.can_record?
+      = link_to user_path(user, user: {can_record: true}, redir_url: manage_users_path(params)), method: :patch do
+        = icon_recording(:alt => t('.allow_record'), :title => t('.allow_record'))
+    - else
+      = link_to user_path(user, user: {can_record: false}, redir_url: manage_users_path(params)), method: :patch do
+        = icon_error(:alt => t('.disallow_record'), :title => t('.disallow_record'))
+
     - unless user.superuser  # prevent admins from disabling and disapproving themselves
       - if user.require_approval? || !user.approved?
         = approval_links :user, user

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -30,7 +30,7 @@
     #user-ldap-info.alert.alert-gray
       %span.title= t('.ldap.title')
 
-= simple_form_for @user, :url => user_path(@user, return_to: previous_path_or(edit_user_path(@user))), :html => { :method => :put } do |f|
+= simple_form_for @user, :url => user_path(@user, redir_url: previous_path_or(edit_user_path(@user))), :html => { :method => :put } do |f|
 
   .left-column
 

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -930,6 +930,7 @@ en:
       disapprove_confirm: "Are you sure you want to block the access to this space?"
       edit: "Edit space"
     enabled_user:
+      allow_record: "Allow user to record"
       approve: "Approve: allow this user to access the website"
       approve_confirm: "Are you sure you want to allow this user to access the website?"
       auth_using: "using"
@@ -938,6 +939,7 @@ en:
       confirm_confirm: "Are you sure you want to confirm this user?"
       disable: "Disable user"
       disable_confirm: "Are you sure you want to disable this user?"
+      disallow_record: "Disallow user to record"
       disapprove: "Disapprove: block user from accessing the website"
       disapprove_confirm: "Are you sure you want to block this user from accessing the website?"
       edit: "Edit user"
@@ -1725,6 +1727,7 @@ en:
     normal_user: "Normal user"
     not_assist: "Not attending"
     not_confirmed: "Not confirmed"
+    not_updated: "User not updated! Update Failed!"
     one: User
     other: Users
     recent_join: "Recent users joined"

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -937,6 +937,7 @@ pt-br:
       disapprove_confirm: "Tem certeza que deseja bloquear o acesso a esta comunidade?"
       edit: "Editar comunidade"
     enabled_user:
+      allow_record: "Conceder permissão de gravação"
       approve: "Aprovar: permitir que este usuário acesse o site"
       approve_confirm: "Tem certeza que deseja permitir que este usuário acesse o site?"
       auth_using: "usando"
@@ -945,6 +946,7 @@ pt-br:
       confirm_confirm: "Tem certeza que deseja confirmar este usuário?"
       disable: "Desabilitar usuário"
       disable_confirm: "Tem certeza que deseja desabilitar este usuário?"
+      disallow_record: "Remover permissão de gravação"
       disapprove: "Desaprovar: bloquear o acesso deste usuário ao site"
       disapprove_confirm: "Tem certeza que deseja bloquear o acesso deste usuário ao site?"
       edit: "Editar usuário"
@@ -1735,6 +1737,7 @@ pt-br:
     normal_user: "Usuário comum"
     not_assist: "Não participarão"
     not_confirmed: "Não confirmados"
+    not_updated: "Usuário não atualizado! Atualização falhou!"
     one: Usuário
     other: Usuários
     recent_join: "Usuários recentemente inscritos"

--- a/spec/features/manage/admin_manages_users_spec.rb
+++ b/spec/features/manage/admin_manages_users_spec.rb
@@ -19,6 +19,7 @@ describe 'Admin manages users' do
 
       login_as(admin, :scope => :user)
       @user1 = FactoryGirl.create(:user)
+      @user1.update_attributes(can_record: true)
       @unapproved_user = FactoryGirl.create(:user)
       @unapproved_user.update_attributes(:approved => false)
       @disabled_user1 = FactoryGirl.create(:user, disabled: true)
@@ -40,6 +41,8 @@ describe 'Admin manages users' do
       it { should have_css '.icon-mconf-confirm-user', :count => 2 }
       it { should have_css '.icon-mconf-approve', :count => 2 }
       it { should have_css '.icon-mconf-superuser', :count => 1 }
+      it { should have_css '.icon-mconf-cant-rec', :count => 4 }
+      it { should have_css '.icon-mconf-can-rec', :count => 1 }
 
       it { should have_content user_description(@user1) }
       it { should have_content user_description(@unapproved_user) }


### PR DESCRIPTION
Now there will be an icon for the users on manage/user so that the admin can give and remove permission to record.

The icon will be red when the user already can record and grey when he can't, the tooltip will inform of the status of this user and clicking the button will switch it.

Resolves #918 