### PR TITLE
Removing blanks from the search_by_terms param

### DIFF
--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -122,7 +122,7 @@ class Space < ActiveRecord::Base
       query_params = []
       query_orders = []
 
-      words.each do |word|
+      words.reject(&:blank?).each do |word|
         str  = "name LIKE ? OR description LIKE ?"
         query_strs << str
         query_params += ["%#{word}%", "%#{word}%"]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -96,7 +96,7 @@ class User < ActiveRecord::Base
       query_params = []
       query_orders = []
 
-      words.each do |word|
+      words.reject(&:blank?).each do |word|
         str  = "profiles.full_name LIKE ? OR users.username LIKE ?"
         str += " OR users.email LIKE ?" if include_private
         query_strs << str

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -15,7 +15,7 @@ Rails.application.config.to_prepare do
       query_strs = []
       query_params = []
 
-      words.each do |word|
+      words.reject(&:blank?).each do |word|
         str  = "name LIKE ?"
         query_strs << str
         query_params += ["%#{word}%"]

--- a/config/initializers/bigbluebutton_rails.rb
+++ b/config/initializers/bigbluebutton_rails.rb
@@ -103,7 +103,7 @@ Rails.application.config.to_prepare do
         query_params = []
         query_orders = []
 
-        words.each do |word|
+        words.reject(&:blank?).each do |word|
           str  = "bigbluebutton_recordings.name LIKE ? OR bigbluebutton_recordings.description LIKE ?"
           str += " OR bigbluebutton_recordings.recordid LIKE ? OR bigbluebutton_rooms.name LIKE ?"
           query_strs << str

--- a/spec/controllers/manage_controller_spec.rb
+++ b/spec/controllers/manage_controller_spec.rb
@@ -247,6 +247,13 @@ describe ManageController do
           it { assigns(:users).count.should be(3) }
           it { assigns(:users).should include(users[0], users[2], users[4]) }
         end
+
+        context "empty space before q: params" do
+          let(:params) { { q: ' reprovado'} }
+
+          it { assigns(:users).count.should be(1) }
+          it { assigns(:users).should include(users[3]) }
+        end
       end
 
       context "use params [:login_method_shib, :login_method_ldap, :login_method_local] to filter the results" do
@@ -474,6 +481,13 @@ describe ManageController do
 
           it { assigns(:spaces).count.should be(1) }
           it { assigns(:spaces).should include(spaces[2]) }
+        end
+
+        context "empty space before q: params" do
+            let(:params) { { q: ' ena'} }
+
+            it { assigns(:spaces).count.should be(1) }
+            it { assigns(:spaces).should include(spaces[2]) }
         end
       end
 
@@ -755,6 +769,13 @@ describe ManageController do
 
           it { assigns(:recordings).count.should be(3) }
           it { assigns(:recordings).should include(recordings[0], recordings[3], recordings[4]) }
+        end
+
+        context "empty space before q: params"do
+          let(:params) { { q: ' unpub'} }
+
+          it { assigns(:recordings).count.should be(1) }
+          it { assigns(:recordings).should include(recordings[1]) }
         end
       end
 


### PR DESCRIPTION
Fixed an issue where having a blank space in the beginning of search_by_terms params would generate a bad query, which would return all the registers of the table.

Now blanks are removed and will not be part of the query.

Resolves #924 