### PR TITLE
Guest login flag #927

### DIFF
--- a/app/assets/stylesheets/app/custom_bigbluebutton_rooms/invite_userid.css.scss
+++ b/app/assets/stylesheets/app/custom_bigbluebutton_rooms/invite_userid.css.scss
@@ -29,9 +29,12 @@ body.custom_bigbluebutton_rooms.invite_userid {
       }
     }
 
-    #webconf-room-userid-member {
-      border-right: 1px solid #ddd;
+    #webconf-room-userid-non-member {
+      padding-bottom: 50px;
+      border-left: 1px solid #ddd;
+    }
 
+    #webconf-room-userid-non-member {
       .container {
         float: right;
       }

--- a/app/controllers/custom_bigbluebutton_rooms_controller.rb
+++ b/app/controllers/custom_bigbluebutton_rooms_controller.rb
@@ -73,7 +73,7 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
   def check_unauth_access_not_logged
     if !current_site.unauth_access_to_conferences && !user_signed_in?
       redirect_to join_webconf_path(id: params[:id])
-      flash[:error] = "ERORR!@"
+      flash[:error] = t('custom_bigbluebutton_rooms.join.unauth_access_to_conferences')
     end
   end
 

--- a/app/controllers/custom_bigbluebutton_rooms_controller.rb
+++ b/app/controllers/custom_bigbluebutton_rooms_controller.rb
@@ -57,8 +57,13 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
 
   def check_redirect_to_invite_userid
     # no user logged and no user set in the URL, go back to the identification step
-    if !user_signed_in? and (params[:user].nil? or params[:user][:name].blank?)
-      redirect_to join_webconf_path(@room)
+    if current_site.unauth_access_to_conferences
+      if !user_signed_in? and (params[:user].nil? or params[:user][:name].blank?)
+        redirect_to join_webconf_path(@room)
+      end
+    else
+      redirect_to join_webconf_path(id: params[:id])
+      flash[:error] = t('custom_bigbluebutton_rooms.join.unauth_access_to_conferences')
     end
   end
 

--- a/app/controllers/custom_bigbluebutton_rooms_controller.rb
+++ b/app/controllers/custom_bigbluebutton_rooms_controller.rb
@@ -24,11 +24,11 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
   before_filter :check_redirect_to_invite, only: [:invite_userid]
   before_filter :check_redirect_to_invite_userid, only: [:invite]
 
-  # can't join or join mobile if not logged and unauthorized is false
-  before_filter :check_unauth_access_not_logged, only: [:join, :join_mobile]
-
   # don't let users join if the room's limit was exceeded
   before_filter :check_user_limit, only: [:join]
+
+  # can't join or join mobile if not logged and unauthorized is false
+  before_filter :check_unauth_access_not_logged, only: [:join, :join_mobile]
 
   # use the patter configured on the site to generate dial numbers
   before_filter :set_site_pattern, only: [:generate_dial_number]

--- a/app/controllers/custom_bigbluebutton_rooms_controller.rb
+++ b/app/controllers/custom_bigbluebutton_rooms_controller.rb
@@ -24,6 +24,9 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
   before_filter :check_redirect_to_invite, only: [:invite_userid]
   before_filter :check_redirect_to_invite_userid, only: [:invite]
 
+  # can't join or join mobile if not logged and unauthorized is false
+  before_filter :check_unauth_access_not_logged, only: [:join, :join_mobile]
+
   # don't let users join if the room's limit was exceeded
   before_filter :check_user_limit, only: [:join]
 
@@ -64,6 +67,13 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
     else
       redirect_to join_webconf_path(id: params[:id])
       flash[:error] = t('custom_bigbluebutton_rooms.join.unauth_access_to_conferences')
+    end
+  end
+
+  def check_unauth_access_not_logged
+    if !current_site.unauth_access_to_conferences && !user_signed_in?
+      redirect_to join_webconf_path(id: params[:id])
+      flash[:error] = "ERORR!@"
     end
   end
 

--- a/app/controllers/custom_bigbluebutton_rooms_controller.rb
+++ b/app/controllers/custom_bigbluebutton_rooms_controller.rb
@@ -64,7 +64,7 @@ class CustomBigbluebuttonRoomsController < Bigbluebutton::RoomsController
       if !user_signed_in? and (params[:user].nil? or params[:user][:name].blank?)
         redirect_to join_webconf_path(@room)
       end
-    else
+    elsif !user_signed_in?
       redirect_to join_webconf_path(id: params[:id])
       flash[:error] = t('custom_bigbluebutton_rooms.join.unauth_access_to_conferences')
     end

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -50,7 +50,7 @@ class SitesController < ApplicationController
      :exception_notifications_email, :exception_notifications_prefix, :presence_domain, :xmpp_server, :external_help,
      :registration_enabled, :require_registration_approval, :local_auth_enabled, :events_enabled, :room_dial_number_pattern,
      :shib_update_users, :require_space_approval, :forbid_user_space_creation, :max_upload_size, :use_gravatar,
-     :captcha_enabled, :recaptcha_public_key, :recaptcha_private_key,
+     :captcha_enabled, :recaptcha_public_key, :recaptcha_private_key, :unauth_access_to_conferences,
      visible_locales: []
     ]
   end

--- a/app/views/custom_bigbluebutton_rooms/invite_userid.html.haml
+++ b/app/views/custom_bigbluebutton_rooms/invite_userid.html.haml
@@ -21,12 +21,13 @@
           = link_to(image_tag("logos/shib_federation_small.jpg"), shibboleth_path)
           = link_to(t(".member.shibboleth.click_here"), shibboleth_path)
 
-  #webconf-room-userid-non-member
-    .container
-      %h3.title= t(".non_member.title")
+  - if !current_site.unauth_access_to_conferences 
+    #webconf-room-userid-non-member
+      .container
+        %h3.title= t(".non_member.title")
 
-      = simple_form_for @room, :url => invite_bigbluebutton_room_path(@room), :method => "get" do |f|
-        .input
-          %label= t(".non_member.name")
-          = text_field_tag "user[name]", "", :required => true
-        = f.button :submit, t(".non_member.next"), :class => "btn btn-primary"
+        = simple_form_for @room, :url => invite_bigbluebutton_room_path(@room), :method => "get" do |f|
+          .input
+            %label= t(".non_member.name")
+            = text_field_tag "user[name]", "", :required => true
+          = f.button :submit, t(".non_member.next"), :class => "btn btn-primary"

--- a/app/views/custom_bigbluebutton_rooms/invite_userid.html.haml
+++ b/app/views/custom_bigbluebutton_rooms/invite_userid.html.haml
@@ -21,7 +21,7 @@
           = link_to(image_tag("logos/shib_federation_small.jpg"), shibboleth_path)
           = link_to(t(".member.shibboleth.click_here"), shibboleth_path)
 
-  - if !current_site.unauth_access_to_conferences 
+  - if current_site.unauth_access_to_conferences?
     #webconf-room-userid-non-member
       .container
         %h3.title= t(".non_member.title")

--- a/app/views/sites/edit.html.haml
+++ b/app/views/sites/edit.html.haml
@@ -62,5 +62,6 @@
     = f.input :forbid_user_space_creation, :as => :boolean
     = f.input :events_enabled, :as => :boolean
     = f.input :use_gravatar, :as => :boolean
+    = f.input :unauth_access_to_conferences, as: :boolean
     = f.input :max_upload_size, as: :string, input_html: { value: @site.formatted_max_upload_size }
   = f.button :wrapped, :cancel => site_path, :value => t("_other.save")

--- a/app/views/sites/show.html.haml
+++ b/app/views/sites/show.html.haml
@@ -58,6 +58,7 @@
     = f.input :forbid_user_space_creation, :as => :boolean, :disabled => true
     = f.input :events_enabled, :as => :boolean, :disabled => true
     = f.input :use_gravatar, :as => :boolean, :disabled => true
+    = f.input :unauth_access_to_conferences, as: :boolean, disabled: true
     = f.input :max_upload_size, as: :string, disabled: true, input_html: { value: @site.formatted_max_upload_size }
   .form-actions
     = link_to t('_other.edit'), edit_site_path, :class => "btn btn-primary"

--- a/config/locales/en/_simple_form.yml
+++ b/config/locales/en/_simple_form.yml
@@ -67,6 +67,7 @@ en:
         smtp_sender: "The email used in the \"From\" header when sending automated emails to users, usually a \"no-reply\" email."
         ssl: "With SSL enabled all the internal links (including pages, images, attachments) will use the protocol HTTPS instead of HTTP"
         use_gravatar: "Fetch user avatars from gravatar if none was uploaded."
+        unauth_access_to_conferences: "Allow users to enter conferences without login."
         xmpp_server: "Address where's located the XMPP server."
       space:
         bigbluebutton_room:

--- a/config/locales/en/mconf.yml
+++ b/config/locales/en/mconf.yml
@@ -510,6 +510,7 @@ en:
         title: "I don't have an account, I will join this room as a guest"
       title: "Join the room: %{name}"
     join:
+      unauth_access_to_conferences: "This meeting requires users to log in to their accounts."
       user_limit_exceeded: "This meeting has reached its limit of participants. Contact the person responsible for the meeting for more information."
     join_mobile:
       click_to_download_android: "Click here to download the Android client"

--- a/config/locales/pt-br/_simple_form.yml
+++ b/config/locales/pt-br/_simple_form.yml
@@ -76,6 +76,7 @@ pt-br:
         smtp_sender: "O e-mail utilizado no campo \"De\" ao enviar e-mails automatizados aos usuários, normalmente um e-mail \"no-reply\"."
         ssl: "Com SSL habilitado todos os links internos (incluindo páginas, imagens, anexos) utilizarão o protocolo https ao invés de http"
         use_gravatar: "Buscar avatar de usuários do Gravatar se nenhum for carregado no portal."
+        unauth_access_to_conferences: "Permitir que usuários entrem nas conferência sem realizar login"
         xmpp_server: "Endereço onde está localizado o servidor XMPP."
       space:
         bigbluebutton_room:

--- a/config/locales/pt-br/mconf.yml
+++ b/config/locales/pt-br/mconf.yml
@@ -517,6 +517,7 @@ pt-br:
         title: "Eu não possuo uma conta, quero entrar como convidado"
       title: "Acessar sala: %{name}"
     join:
+      unauth_access_to_conferences: "Esta conferência requer que os usuários estejam logados em suas contas."
       user_limit_exceeded: "Esta conferência chegou ao seu limite de usuários. Contate o responsável pela conferência para mais detalhes."
     join_mobile:
       click_to_download_android: "Clique aqui para baixar o cliente Android"

--- a/db/migrate/20170119195523_add_unauth_access_to_conferences_to_site.rb
+++ b/db/migrate/20170119195523_add_unauth_access_to_conferences_to_site.rb
@@ -1,0 +1,5 @@
+class AddUnauthAccessToConferencesToSite < ActiveRecord::Migration
+  def change
+    add_column :sites, :unauth_access_to_conferences, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161109164815) do
+ActiveRecord::Schema.define(version: 20170119195523) do
 
   create_table "activities", force: true do |t|
     t.integer  "trackable_id"
@@ -383,6 +383,7 @@ ActiveRecord::Schema.define(version: 20161109164815) do
     t.boolean  "shib_update_users",              default: false
     t.boolean  "use_gravatar",                   default: false
     t.string   "smtp_receiver"
+    t.boolean  "unauth_access_to_conferences",   default: true
   end
 
   create_table "spaces", force: true do |t|

--- a/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
+++ b/spec/controllers/custom_bigbluebutton_rooms_controller_spec.rb
@@ -521,6 +521,44 @@ describe CustomBigbluebuttonRoomsController do
           end
         end
 
+        context "testing the unauth_access_to_conferences flag when a guest is trying to enter a meeting" do
+          let(:user) { FactoryGirl.create(:user) }
+          let(:hash) { { :name => "Elftor", :key => room.attendee_key } }
+          let(:room) { user.bigbluebutton_room }
+          before {
+            BigbluebuttonRoom.stub(:find_by!) { room }
+            controller.should_receive(:check_user_limit) { true }
+          }
+
+          context "when a meeting is running and the flag is true" do
+            before {
+              Site.current.update_attributes(unauth_access_to_conferences: true)
+              room.stub(:is_running?) { true }
+              room.should_receive(:fetch_is_running?).at_least(:once) { true }
+              room.should_receive(:fetch_meeting_info)
+            }
+            it "gets to the room" do
+              send(method, :join, :id => room.to_param, :user => hash)
+              should_not redirect_to join_webconf_path(room)
+              should_not set_flash.to(I18n.t('custom_bigbluebutton_rooms.join.unauth_access_to_conferences'))
+            end
+          end
+
+          context "when a meeting is running and the flag is false" do
+            before {
+              Site.current.update_attributes(unauth_access_to_conferences: false) #this is breaking check user limit?!
+              room.stub(:is_running?) { true }
+              room.should_receive(:fetch_is_running?).at_least(:once) { true }
+              room.should_receive(:fetch_meeting_info)
+            }
+            it "fails to get to the room" do
+              send(method, :join, :id => room.to_param, :user => hash)
+              should redirect_to join_webconf_path(room)
+              should set_flash.to(I18n.t('custom_bigbluebutton_rooms.join.unauth_access_to_conferences'))
+            end
+          end
+        end
+
         # important to check this because join runs methods such as ApplicationController.bigbluebutton_role
         # that need the information fetch in the before filters
         context "#join is called with the same @room that we fetched information from" do


### PR DESCRIPTION
Added the flag.
Unauthorized users can't login and join + join_mobile will not join if no user is logged and the flag is set false.
This flag ENABLES login without authentication, thus TRUE means guests can login.

Resolves #927 