### PR TITLE
Allow users to change name and url of webconference rooms

### DIFF
--- a/app/assets/javascripts/app/application/base.js.coffee
+++ b/app/assets/javascripts/app/application/base.js.coffee
@@ -122,7 +122,9 @@ class mconf.Base
   # Converts a string into a slug. Should do it as closely as possible from the
   # way slugs are generated in the application using FriendlyId.
   # From: http://dense13.com/blog/2009/05/03/converting-string-to-slug-javascript/
-  @stringToSlug: (str) ->
+  # direct_input is a boolean to allow more freedom if the slug is applied to the
+  # same field the user is currently editing
+  @stringToSlug: (str, direct_input=false) ->
     return '' if !str?
 
     str = str.toLowerCase()
@@ -130,8 +132,12 @@ class mconf.Base
     str = str.replace(/[^A-Za-z0-9\-_ ]*/g, '')
        .replace(/\s+/g, '-')         # collapse whitespace and replace by '-'
        .replace(/-+/g, '-')          # collapse dashes
-       .replace(/-$/g, '')           # dash as the last char
        .replace(/^-/g, '')           # dash as the first char
+
+    if direct_input is false
+      str = str.replace(/-$/g, '')   # dash as the last char
+
+    str
 
   # Returns whether an email is valid or not.
   # From: http://www.w3resource.com/javascript/form/email-validation.php

--- a/app/assets/javascripts/app/custom_bigbluebutton_rooms/user_edit.js.coffee
+++ b/app/assets/javascripts/app/custom_bigbluebutton_rooms/user_edit.js.coffee
@@ -1,0 +1,8 @@
+class mconf.UserEdit
+  @setup: ->
+    $param = $("#bigbluebutton_room_param:not(.disabled)")
+    $param.attr "value", mconf.Base.stringToSlug($param.val(), true)
+    $param.on "input", () ->
+      $param.val(mconf.Base.stringToSlug($param.val(), true))
+    $param.on "blur", () ->
+      $param.val(mconf.Base.stringToSlug($param.val(), false))

--- a/app/assets/javascripts/app/my/_all.js.coffee
+++ b/app/assets/javascripts/app/my/_all.js.coffee
@@ -1,6 +1,7 @@
 # There are things in the header that are used in several pages in this controller
 
 #= require "../custom_bigbluebutton_rooms/_invitation_form"
+#= require "../custom_bigbluebutton_rooms/user_edit"
 
 $ ->
   if isOnPage 'my', 'home'
@@ -8,6 +9,7 @@ $ ->
     # set to rebind things when the resources are rebound
     mconf.Resources.addToBind ->
       mconf.CustomBigbluebuttonRooms.Invitation.bind()
+      mconf.UserEdit.setup()
 
     # this modal binds some things in the modal using "global" selectors such as ".modal"
     # so we make sure we unbind everything when the modal is closed

--- a/app/assets/javascripts/app/spaces/_sidebar.js.coffee
+++ b/app/assets/javascripts/app/spaces/_sidebar.js.coffee
@@ -1,4 +1,5 @@
 #= require "../custom_bigbluebutton_rooms/_invitation_form"
+#= require "../custom_bigbluebutton_rooms/user_edit"
 
 mconf.Spaces or= {}
 
@@ -12,7 +13,7 @@ class mconf.Spaces.Sidebar
     # set to rebind thing when the resources are rebound
     mconf.Resources.addToBind ->
       mconf.CustomBigbluebuttonRooms.Invitation.bind()
-
+      mconf.UserEdit.setup()
     # this modal binds some things in the modal using "global" selectors such as ".modal"
     # so we make sure we unbind everything when the modal is closed
     $("#sidebar-webconference .webconf-join-group .open-modal").on "modal-hidden.mconfSpacesSidebar", ->

--- a/app/assets/javascripts/app/spaces/webconference.js.coffee
+++ b/app/assets/javascripts/app/spaces/webconference.js.coffee
@@ -1,4 +1,5 @@
 #= require "../custom_bigbluebutton_rooms/_invitation_form"
+#= require "../custom_bigbluebutton_rooms/user_edit"
 
 mconf.Spaces or= {}
 
@@ -9,6 +10,7 @@ class mconf.Spaces.Webconference
 
     mconf.Resources.addToBind ->
       mconf.CustomBigbluebuttonRooms.Invitation.bind()
+      mconf.UserEdit.setup()
 
     $("#webconference-share .open-modal").on "modal-hidden.mconfSpacesWebconference", ->
       mconf.CustomBigbluebuttonRooms.Invitation.unbind()

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -25,10 +25,12 @@ class Profile < ActiveRecord::Base
 
   def update_webconf_room
     if self.full_name_changed?
-      params = {
-        :name => self.full_name
-      }
-      self.user.bigbluebutton_room.update_attributes(params)
+      if self.full_name_was == self.user.bigbluebutton_room.name
+        params = {
+          :name => self.full_name
+        }
+        self.user.bigbluebutton_room.update_attributes(params)
+      end
     end
   end
 

--- a/app/models/space.rb
+++ b/app/models/space.rb
@@ -346,10 +346,12 @@ class Space < ActiveRecord::Base
   # Updates the webconf room after updating the space
   def update_webconf_room
     if self.bigbluebutton_room
-      params = {
-        :name => self.name
-      }
-      bigbluebutton_room.update_attributes(params)
+      if self.name_was == self.bigbluebutton_room.name
+        params = {
+          :name => self.name
+        }
+        bigbluebutton_room.update_attributes(params)
+      end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -79,7 +79,6 @@ class User < ActiveRecord::Base
   accepts_nested_attributes_for :bigbluebutton_room
 
   after_create :create_webconf_room
-  after_update :update_webconf_room
 
   before_destroy :before_disable_and_destroy, prepend: true
 
@@ -182,13 +181,6 @@ class User < ActiveRecord::Base
       :attendee_key => SecureRandom.hex(4)
     }
     create_bigbluebutton_room(params)
-  end
-
-  def update_webconf_room
-    if self.username_changed?
-      params = { param: self.username }
-      bigbluebutton_room.update_attributes(params)
-    end
   end
 
   # Full location: city + country

--- a/app/views/custom_bigbluebutton_rooms/user_edit.html.haml
+++ b/app/views/custom_bigbluebutton_rooms/user_edit.html.haml
@@ -10,7 +10,7 @@
     .modal-body
       = hidden_field_tag :redir_url, @redir_url
       = disable_autocomplete_for('bigbluebutton_room[name]')
-      = f.input :name, :as => :string, :hint => t('simple_form.hints.user.bigbluebutton_room.name')
+      = f.input :name, label: t('simple_form.labels.bigbluebutton_room.name'), :as => :string, :hint => t('simple_form.hints.user.bigbluebutton_room.name')
       = disable_autocomplete_for('bigbluebutton_room[param]')
       = f.input :param, label: t('simple_form.labels.bigbluebutton_room.url'), :as => :string, :hint => t('simple_form.hints.user.bigbluebutton_room.url'), :wrapper => :prepend do
         = content_tag :span, webconf_url_prefix, :class => "input-group-addon"

--- a/app/views/custom_bigbluebutton_rooms/user_edit.html.haml
+++ b/app/views/custom_bigbluebutton_rooms/user_edit.html.haml
@@ -6,11 +6,19 @@
 
   -# TODO: this should be a form to current_user, with a simple_fields_for :bigbluebutton_room
   -#   inside it.
-  = simple_form_for @room, :html => { :class => "single-column" } do |f|
+  = simple_form_for @room, :html => { :class => "single-column",  autocomplete: 'off' } do |f|
     .modal-body
       = hidden_field_tag :redir_url, @redir_url
+      = disable_autocomplete_for('bigbluebutton_room[name]')
+      = f.input :name, :as => :string, :hint => t('simple_form.hints.user.bigbluebutton_room.name')
+      = disable_autocomplete_for('bigbluebutton_room[param]')
+      = f.input :param, label: t('simple_form.labels.bigbluebutton_room.url'), :as => :string, :hint => t('simple_form.hints.user.bigbluebutton_room.url'), :wrapper => :prepend do
+        = content_tag :span, webconf_url_prefix, :class => "input-group-addon"
+        = f.input_field :param
       = f.input :private, :hint => t('simple_form.hints.user.bigbluebutton_room.private')
+      = disable_autocomplete_for('bigbluebutton_room[moderator_key]', 'password')
       = f.input :moderator_key, :as => :showable_password, :hint => t('simple_form.hints.user.bigbluebutton_room.moderator_key')
+      = disable_autocomplete_for('bigbluebutton_room[attendee_key]', 'password')
       = f.input :attendee_key, :as => :showable_password, :hint => t('simple_form.hints.user.bigbluebutton_room.attendee_key')
       - unless @room.dial_number.blank?
         = f.input :dial_number, as: :string, disabled: true

--- a/config/locales/en/_simple_form.yml
+++ b/config/locales/en/_simple_form.yml
@@ -21,7 +21,8 @@ en:
         edit:
           password: "New password"
       bigbluebutton_room:
-        url: "Url"
+        name: "Webconference room name"
+        url: "Webconference room address"
     hints:
       bigbluebutton_room:
         dial_number: "A dial access number that participants can call in using regular phone."

--- a/config/locales/en/_simple_form.yml
+++ b/config/locales/en/_simple_form.yml
@@ -20,6 +20,8 @@ en:
       user:
         edit:
           password: "New password"
+      bigbluebutton_room:
+        url: "Url"
     hints:
       bigbluebutton_room:
         dial_number: "A dial access number that participants can call in using regular phone."
@@ -88,8 +90,11 @@ en:
           auto_start_audio: "Check this option to automatically share a user's microphone after joining a meeting"
           auto_start_video: "Check this option to automatically share a user's camera after joining a meeting"
           moderator_key: "A key for users to join the session as moderators. Do not reuse real passwords here. This key will only be necessary if the room is set as private."
+          name: "The name of the room for this webconference, as will be seen by all attendees during the meeting."
           presenter_share_only: "When set to true only the presenter is allowed to share his webcam and microphone. This is great for one-to-many conferences."
           private: "Private rooms require a password for users to join. Public rooms can be accessed by anyone with its link. Only you can start a conference in your room, regardless of if it's private or public."
+          url: "The url that will be used to access this webconference room for this meeting."
+          url_label: "Url"
           welcome_msg: "This message will be shown on the chat when a user joins the conference. Leave it empty to use the default message. You can include meeting specific information with the variables %%CONFNAME%%, %%DIALNUM%% and %%CONFNUM%%"
         can_record: "Check this option to allow this user to record meetings in his personal room or in rooms of spaces he belongs to"
         dial_number: "A dial access number that participants can call in using regular phone."

--- a/config/locales/pt-br/_simple_form.yml
+++ b/config/locales/pt-br/_simple_form.yml
@@ -20,6 +20,8 @@ pt-br:
       user:
         edit:
           password: "Nova senha"
+      bigbluebutton_room:
+        url: "Url"
     hints:
       bigbluebutton_room:
         dial_number: "O número de telefone da conferência para o qual os participantes podem discar usando uma linha telefônica."
@@ -97,7 +99,10 @@ pt-br:
           auto_start_video: "Habilite para automaticamente iniciar o compartilhamento de câmera assim que o usuário entra na conferência"
           auto_start_audio: "Habilite para automaticamente iniciar o compartilhamento de microfone assim que o usuário entra na conferência"
           moderator_key: "Chave para que os usuários acessem uma reunião com papel de moderador. Não reutilize senhas reais aqui. Esta senha só será necessária se a sala for privada."
+          name: "Nome da sala para esta webconferência, como será vista pelos usuários durante a reunião."
           presenter_share_only: "Habilite para somente permitir que o apresentador compartilhe sua câmera e microfone. Utilizado em conferências \"um para muitos\"."
+          url: "Url que será usada pelos usuários para acessar para esta reunião"
+          url_label: "Url"
           welcome_msg: "Essa mensagem é exibida no bate-papo quando um usuário entrar na conferência. Deixe em branco para usar a mensagem padrão. Você pode incluir informações específicas à conferência usando as variáveis %%CONFNAME%%, %%DIALNUM%% e %%CONFNUM%%"
         can_record: "Marque esta opção para permitir que este usuário grave reuniões na sua sala pessoal ou em salas de comunidades às quais ele pertence"
         dial_number: "O número de telefone da conferência para o qual os participantes podem discar usando uma linha telefônica."

--- a/config/locales/pt-br/_simple_form.yml
+++ b/config/locales/pt-br/_simple_form.yml
@@ -21,7 +21,8 @@ pt-br:
         edit:
           password: "Nova senha"
       bigbluebutton_room:
-        url: "Url"
+        name: "Nome da sala de webconferência"
+        url: "Endereço da sala de webconferência"
     hints:
       bigbluebutton_room:
         dial_number: "O número de telefone da conferência para o qual os participantes podem discar usando uma linha telefônica."

--- a/lib/tasks/db/populate.rake
+++ b/lib/tasks/db/populate.rake
@@ -258,7 +258,6 @@ namespace :db do
       # Several meetings with recordings
       BigbluebuttonMeeting.populate 0..35 do |meeting|
         meeting.room_id = room.id
-        meeting.server_id = room.server.id
         meeting.meetingid = room.meetingid
         meeting.create_time = (Time.now-1.year).to_i..Time.now.to_i
         meeting.name = Populator.words(3..5).titleize
@@ -276,7 +275,6 @@ namespace :db do
 
         BigbluebuttonRecording.populate 1..1 do |recording|
           recording.room_id = room.id
-          recording.server_id = BigbluebuttonServer.default.id
           recording.meeting_id = meeting.id
           recording.recordid = "rec-#{SecureRandom.hex(16)}-#{Time.now.to_i}"
           recording.meetingid = room.meetingid
@@ -315,7 +313,6 @@ namespace :db do
       # Create a few meetings that have no recording associated
       BigbluebuttonMeeting.populate 0..10 do |meeting|
         meeting.room_id = room.id
-        meeting.server_id = room.server.id
         meeting.meetingid = room.meetingid
         meeting.create_time = (Time.now-1.year).to_i..Time.now.to_i
         meeting.name = Populator.words(3..5).titleize

--- a/spec/models/profile_spec.rb
+++ b/spec/models/profile_spec.rb
@@ -251,13 +251,24 @@ describe Profile do
     let(:user) { FactoryGirl.create(:user) }
     let(:profile) { user.profile }
 
-    context "updates the name of the user's web conference room" do
+    context "updates the name of the user's web conference room if both were equal" do
       before(:each) {
+        profile.update_attributes(full_name: "name before")
         profile.user.bigbluebutton_room.update_attribute(:name, "name before")
-        profile.update_attributes(:full_name => "name after")
+        profile.update_attributes(full_name: "name after")
       }
 
       it { profile.user.bigbluebutton_room.name.should eq("name after") }
+    end
+
+    context "does not update the name of the user's web conference room if both were different" do
+      before(:each) {
+        profile.update_attributes(full_name: "name before")
+        profile.user.bigbluebutton_room.update_attribute(:name, "other name")
+        profile.update_attributes(full_name: "name after")
+      }
+
+      it { profile.user.bigbluebutton_room.name.should eq("other name") }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -372,7 +372,7 @@ describe User do
     context "updates the webconf room" do
       let(:user) { FactoryGirl.create(:user, :username => "old-user-name") }
       before(:each) { user.update_attributes(:username => "new-user-name") }
-      it { user.bigbluebutton_room.param.should be(user.username) }
+      it { user.bigbluebutton_room.param.should_not be(user.username) }
       it { user.bigbluebutton_room.name.should_not be(user.username) }
     end
   end


### PR DESCRIPTION
    - Users can now edit their webconference room name and URL
    - Users can also edit the name and URL of their spaces webconference rooms,
      if they match the required abilities/permissions
    - The name of the webconference room will still be updated when the user fullname
      (profile) is updated, but only if the room name and user full name are currently the same
    - The URL is no longer going to update when a user's username (user) is updated,
      since a user currently can't change his username, therefore, URLs will be generated once
      when a user creates his account and then only updated by user input
    - Space URL can be updated and follows the same behavior
    - There is no flag to enable editing name and url, it will be a default behavior

Resolves #363 and #934 