### PR TITLE
Adding tables and scheduling worker for new get_stats implementation

### DIFF
--- a/config/workers_schedule.yml
+++ b/config/workers_schedule.yml
@@ -40,6 +40,13 @@ finish_meetings:
   queue: low
   description: "Checks for meetings that finished and mark as finished. Same as 'rake bigbluebutton_rails:meetings:finish'."
 
+get_stats:
+  every:
+    - "2m"
+  class: BigbluebuttonGetStats
+  queue: low
+  description: "Checks for meeting's stats. Currently works on Mconf-Live servers and will get a list of participants and meeting duration. Same as 'rake bigbluebutton_rails:meetings:get_stats'"
+
 update_recordings:
   every:
     - "30m"

--- a/db/migrate/20170531162723_bigbluebutton_rails_to220b.rb
+++ b/db/migrate/20170531162723_bigbluebutton_rails_to220b.rb
@@ -1,0 +1,21 @@
+class BigbluebuttonRailsTo220b < ActiveRecord::Migration
+  def up
+    create_table :bigbluebutton_attendees do |t|
+      t.string :user_id
+      t.string :extern_user_id
+      t.string :user_name
+      t.decimal :join_time, precision: 14, scale: 0
+      t.decimal :left_time, precision: 14, scale: 0
+      t.integer :bigbluebutton_meeting_id
+    end
+
+    add_column :bigbluebutton_meetings, :finish_time, :decimal, precision: 14, scale: 0
+    add_column :bigbluebutton_meetings, :got_stats, :string
+  end
+
+  def down
+    drop_table :bigbluebutton_attendees
+    remove_column :bigbluebutton_meetings, :finish_time
+    remove_column :bigbluebutton_meetings, :got_stats
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170425163351) do
+ActiveRecord::Schema.define(version: 20170531162723) do
 
   create_table "activities", force: true do |t|
     t.integer  "trackable_id"
@@ -58,6 +58,15 @@ ActiveRecord::Schema.define(version: 20170425163351) do
     t.string   "attachment"
   end
 
+  create_table "bigbluebutton_attendees", force: true do |t|
+    t.string  "user_id"
+    t.string  "extern_user_id"
+    t.string  "user_name"
+    t.decimal "join_time",                precision: 14, scale: 0
+    t.decimal "left_time",                precision: 14, scale: 0
+    t.integer "bigbluebutton_meeting_id"
+  end
+
   create_table "bigbluebutton_meetings", force: true do |t|
     t.integer  "server_id"
     t.integer  "room_id"
@@ -73,6 +82,8 @@ ActiveRecord::Schema.define(version: 20170425163351) do
     t.string   "server_secret"
     t.decimal  "create_time",   precision: 14, scale: 0
     t.boolean  "ended",                                  default: false
+    t.decimal  "finish_time",   precision: 14, scale: 0
+    t.string   "got_stats"
   end
 
   add_index "bigbluebutton_meetings", ["meetingid", "create_time"], name: "index_bigbluebutton_meetings_on_meetingid_and_create_time", unique: true, using: :btree


### PR DESCRIPTION
will add a list of attendees and finish time info for meetings on servers with getStats api call

resolves #619 
