### PR TITLE
Removed enable_events flag

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -48,10 +48,11 @@ class SitesController < ApplicationController
      :ldap_user_treebase, :ldap_username_field, :ldap_email_field, :ldap_name_field, :ldap_filter, :smtp_login, :smtp_password,
      :smtp_sender, :smtp_receiver, :smtp_domain, :smtp_server, :smtp_port, :smtp_use_tls, :smtp_auto_tls, :smtp_auth_type, :exception_notifications,
      :exception_notifications_email, :exception_notifications_prefix, :external_help,
-     :registration_enabled, :require_registration_approval, :local_auth_enabled, :spaces_enabled, :events_enabled, :activities_enabled,
+     :registration_enabled, :require_registration_approval, :local_auth_enabled, :spaces_enabled, :activities_enabled,
      :room_dial_number_pattern, :shib_update_users, :require_space_approval, :forbid_user_space_creation, :max_upload_size, :use_gravatar,
      :captcha_enabled, :recaptcha_public_key, :recaptcha_private_key, :unauth_access_to_conferences,
      :certificate_login_enabled, :certificate_id_field, :certificate_name_field,
+     #:events_enabled,
      visible_locales: []
     ]
   end

--- a/app/views/sites/edit.html.haml
+++ b/app/views/sites/edit.html.haml
@@ -11,7 +11,7 @@
     = f.input :ssl, :as => :boolean
     = f.input :feedback_url, :hint => t('simple_form.hints.site.feedback_url', :default_url => webconf_feedback_index_path)
     = f.input :spaces_enabled, as: :boolean
-    = f.input :events_enabled, as: :boolean
+    -#  = f.input :events_enabled, as: :boolean
     = f.input :activities_enabled, as: :boolean
     = f.input :external_help
     = f.input :registration_enabled, :as => :boolean


### PR DESCRIPTION
The code for events was not removed, the flag will not be available
until events module is upgraded and serves a clearer/better function