### PR TITLE
remove an s from count in horas

### DIFF
--- a/config/locales/es-419/_dotiw.yml
+++ b/config/locales/es-419/_dotiw.yml
@@ -9,7 +9,7 @@ es-419:
         other: '%{count} minutes'
       hours:
         one: 1 hora
-        other: '%{counts} horas'
+        other: '%{count} horas'
       days:
         one: 1 día
         other: '%{count} días'


### PR DESCRIPTION
There was an extra s in {count} parameter, which generated an error 500 when accessing the recording list of any space in Spanish